### PR TITLE
Update test config to test rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 cache: bundler
 
 rvm:
+  - 2.5.5
   - 2.6.3
 
 before_install: gem install bundler -v 2.0.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ cache: bundler
 rvm:
   - 2.5.5
   - 2.6.3
+gemfile:
+  - ci/gemfiles/Gemfile.rails-5.2.x
+  - ci/gemfiles/Gemfile.rails-6.0.x
 
 before_install: gem install bundler -v 2.0.2
 before_script:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Work closely with your Southern Made project manager to gather details about wha
 
 ## Installation
 
+This gem is tested with Rails 5.2.x, 6.0.x versions.
+
 Add this line to your application's Gemfile:
 
 ```ruby

--- a/ci/gemfiles/Gemfile.rails-5.2.x
+++ b/ci/gemfiles/Gemfile.rails-5.2.x
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gemspec
+gem "rails", "~> 5.2.3"

--- a/ci/gemfiles/Gemfile.rails-5.2.x
+++ b/ci/gemfiles/Gemfile.rails-5.2.x
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
-gemspec
+
+# Specify your gem's dependencies in sm_sms_campaign_webhook.gemspec
+gemspec path: "../../."
+
 gem "rails", "~> 5.2.3"

--- a/ci/gemfiles/Gemfile.rails-6.0.x
+++ b/ci/gemfiles/Gemfile.rails-6.0.x
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gemspec
+gem "rails", "= 6.0.0.rc1"

--- a/ci/gemfiles/Gemfile.rails-6.0.x
+++ b/ci/gemfiles/Gemfile.rails-6.0.x
@@ -1,3 +1,6 @@
 source "https://rubygems.org"
-gemspec
+
+# Specify your gem's dependencies in sm_sms_campaign_webhook.gemspec
+gemspec path: "../../."
+
 gem "rails", "= 6.0.0.rc1"

--- a/sm_sms_campaign_webhook.gemspec
+++ b/sm_sms_campaign_webhook.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
-
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/SouthernMade/sm_sms_campaign_webhook"
   spec.metadata["changelog_uri"] = "https://github.com/SouthernMade/sm_sms_campaign_webhook/blob/develop/CHANGELOG.md"
@@ -26,6 +25,9 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  # Required version of Ruby guided by Rails.
+  spec.required_ruby_version = "~> 2.5"
 
   # Runtime dependencies.
   spec.add_dependency "rails", "~> 5.2.3"

--- a/sm_sms_campaign_webhook.gemspec
+++ b/sm_sms_campaign_webhook.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 2.5"
 
   # Runtime dependencies.
-  spec.add_dependency "rails", "~> 5.2.3"
+  spec.add_dependency "rails", [">= 5.2.3", "< 6.1"]
 
   # Development + test dependencies.
   spec.add_development_dependency "bundler", "~> 2.0"


### PR DESCRIPTION
This closes #9. It includes:

* Setting required Ruby version to lowest supported by Rails v6.0.x
* Updating gemspec to permit Rails versions between v5.2.x and v6.1
* Adding CI gemfiles with explicit Rails versions
* Updating CI config to test Ruby 2.5.5 + 2.6.3
* Updating CI config to test with CI gemfiles

This verifies that Travis CI is running all four test scenarios:

<img width="1454" alt="Screen Shot 2019-07-18 at 10 18 19 AM" src="https://user-images.githubusercontent.com/22482/61469783-70b10e00-a945-11e9-85e7-bec4a4afb57b.png">
