### PR TITLE
Add campaign engagement serializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mountable Rails engine as API
 - POST /api/webhook resource
 - Support for Rails 5.2.x, 6.0.x
+- Data models to serialize campaign engagement event payloads
+- Helper method to get specific campaign engagement answer
 
 ### Changed
 - Require Ruby >= 2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Mountable Rails engine as API
+- POST /api/webhook resource
+- Support for Rails 5.2.x, 6.0.x
+
+### Changed
+- Require Ruby >= 2.5
+- CI to test against Ruby 2.5.5, 2.6.3
+- CI to test against Rails 5.2.x, 6.0.x
 
 ## [0.1.1] - 2019-07-16
 ### Changed

--- a/app/exceptions/sm_sms_campaign_webhook/error.rb
+++ b/app/exceptions/sm_sms_campaign_webhook/error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module SmSmsCampaignWebhook
+  # General base error type for custom errors.
+  class Error < StandardError; end
+end

--- a/app/exceptions/sm_sms_campaign_webhook/invalid_payload.rb
+++ b/app/exceptions/sm_sms_campaign_webhook/invalid_payload.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module SmSmsCampaignWebhook
-  # Error type for invalid data received by the SMS webhook.
+  # Error type for invalid payload schema received by the SMS webhook.
   class InvalidPayload < Error; end
 end

--- a/app/exceptions/sm_sms_campaign_webhook/invalid_payload.rb
+++ b/app/exceptions/sm_sms_campaign_webhook/invalid_payload.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module SmSmsCampaignWebhook
+  # Error type for invalid data received by the SMS webhook.
+  class InvalidPayload < Error; end
+end

--- a/app/exceptions/sm_sms_campaign_webhook/invalid_payload_value.rb
+++ b/app/exceptions/sm_sms_campaign_webhook/invalid_payload_value.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module SmSmsCampaignWebhook
+  # Error type for invalid value in the payload received by the SMS webhook.
+  class InvalidPayloadValue < Error; end
+end

--- a/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
+++ b/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
@@ -36,6 +36,7 @@ module SmSmsCampaignWebhook
 
     # @return [DateTime] Campaign engagement event timestamp
     # @raise [InvalidPayload] when created_at missing from payload
+    # @raise [InvalidPayloadValue] when created_at not datetime
     def event_created_at
       @event_created_at ||= begin
         raw_created_at = payload.fetch("created_at") do
@@ -44,6 +45,9 @@ module SmSmsCampaignWebhook
         end
         DateTime.parse(raw_created_at).freeze
       end
+    rescue ArgumentError
+      raise InvalidPayloadValue,
+            "created_at has invalid datetime value #{payload.inspect}"
     end
 
     # @return [Integer] ID of the engaged campaign
@@ -131,6 +135,7 @@ module SmSmsCampaignWebhook
 
     # @return [DateTime,NilClass] Timestamp of campaign engagement completion if completed
     # @raise [InvalidPayload] when phone_campaign_state completed_at missing from payload
+    # @raise [InvalidPayloadValue] when phone_campaign_state completed_at not datetime
     def phone_campaign_state_completed_at
       @phone_campaign_state_completed_at ||= begin
         raw_completed_at = phone_campaign_state_hash.fetch("completed_at") do
@@ -139,6 +144,9 @@ module SmSmsCampaignWebhook
         end
         DateTime.parse(raw_completed_at).freeze if raw_completed_at
       end
+    rescue ArgumentError
+      raise InvalidPayloadValue,
+            "phone_campaign_state completed_at has invalid datetime value #{payload.inspect}"
     end
 
     private

--- a/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
+++ b/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
@@ -119,6 +119,7 @@ module SmSmsCampaignWebhook
 
     # @return [TrueClass,FalseClass] Has campaign engagement completed?
     # @raise [InvalidPayload] when phone_campaign_state completed missing from payload
+    # @raise [InvalidPayloadValue] when phone_campaign_state completed is not boolean
     def phone_campaign_state_completed?
       # Has the boolean value already been assigned?
       if !@phone_campaign_state_completed.nil?
@@ -126,11 +127,21 @@ module SmSmsCampaignWebhook
       end
 
       # Extract the value and memoize it.
-      @phone_campaign_state_completed = phone_campaign_state_hash
-        .fetch("completed") do
-          raise InvalidPayload,
-                "phone_campaign_state completed missing from payload #{payload.inspect}"
+      @phone_campaign_state_completed = begin
+        completed = phone_campaign_state_hash
+          .fetch("completed") do
+            raise InvalidPayload,
+                  "phone_campaign_state completed missing from payload #{payload.inspect}"
+          end
+
+        # Is this a boolean value?
+        if [true, false].none?(completed)
+          raise InvalidPayloadValue,
+                "phone_campaign_state completed has invalid boolean value #{payload.inspect}"
         end
+
+        completed
+      end
     end
 
     # @return [DateTime,NilClass] Timestamp of campaign engagement completion if completed

--- a/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
+++ b/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
@@ -13,49 +13,82 @@ module SmSmsCampaignWebhook
     end
 
     # @return [String] Campaign engagement event UUID
+    # @raise [InvalidPayload] when uuid missing from payload
     def event_uuid
-      @event_uuid ||= payload.fetch("uuid").freeze
+      @event_uuid ||= payload.fetch("uuid") do
+        raise InvalidPayload,
+              "uuid missing from payload #{payload.inspect}"
+      end.freeze
     end
 
     # @return [String] Campaign engagement event type
+    # @raise [InvalidPayload] when type missing from payload
     def event_type
-      @event_type ||= payload.fetch("type").freeze
+      @event_type ||= payload.fetch("type") do
+        raise InvalidPayload,
+              "type missing from payload #{payload.inspect}"
+      end.freeze
     end
 
     # @return [DateTime] Campaign engagement event timestamp
+    # @raise [InvalidPayload] when created_at missing from payload
     def event_created_at
       @event_created_at ||= begin
-        raw_created_at = payload.fetch("created_at")
+        raw_created_at = payload.fetch("created_at") do
+          raise InvalidPayload,
+                "created_at missing from payload #{payload.inspect}"
+        end
         DateTime.parse(raw_created_at).freeze
       end
     end
 
     # @return [Integer] ID of the engaged campaign
+    # @raise [InvalidPayload] when campaign id missing from payload
     def campaign_id
-      @campaign_id ||= campaign_hash.fetch("id")
+      @campaign_id ||= campaign_hash.fetch("id") do
+        raise InvalidPayload,
+              "campaign id missing from payload #{payload.inspect}"
+      end
     end
 
     # @return [String] Keyword of the engaged campaign
+    # @raise [InvalidPayload] when campaign keyword missing from payload
     def campaign_keyword
-      @campaign_keyword ||= campaign_hash.fetch("keyword").freeze
+      @campaign_keyword ||= campaign_hash.fetch("keyword") do
+        raise InvalidPayload,
+              "campaign keyword missing from payload #{payload.inspect}"
+      end.freeze
     end
 
     # @return [String] ID of the engaging phone
+    # @raise [InvalidPayload] when phone id missing from payload
     def phone_id
-      @phone_id ||= phone_hash.fetch("id")
+      @phone_id ||= phone_hash.fetch("id") do
+        raise InvalidPayload,
+              "phone id missing from payload #{payload.inspect}"
+      end
     end
 
     # @return [String] Phone number engaging the campaign
+    # @raise [InvalidPayload] when phone number missing from payload
     def phone_number
-      @phone_number ||= phone_hash.fetch("number").freeze
+      @phone_number ||= phone_hash.fetch("number") do
+        raise InvalidPayload,
+              "phone number missing from payload #{payload.inspect}"
+      end.freeze
     end
 
     # @return [Integer] ID of campaign engagement state record
+    # @raise [InvalidPayload] when phone_campaign_state id missing from payload
     def phone_campaign_state_id
-      @phone_campaign_state_id ||= phone_campaign_state_hash.fetch("id")
+      @phone_campaign_state_id ||= phone_campaign_state_hash.fetch("id") do
+        raise InvalidPayload,
+              "phone_campaign_state id missing from payload #{payload.inspect}"
+      end
     end
 
     # @return [TrueClass,FalseClass] Has campaign engagement completed?
+    # @raise [InvalidPayload] when phone_campaign_state completed missing from payload
     def phone_campaign_state_completed?
       # Has the boolean value already been assigned?
       if !@phone_campaign_state_completed.nil?
@@ -64,13 +97,20 @@ module SmSmsCampaignWebhook
 
       # Extract the value and memoize it.
       @phone_campaign_state_completed = phone_campaign_state_hash
-        .fetch("completed")
+        .fetch("completed") do
+          raise InvalidPayload,
+                "phone_campaign_state completed missing from payload #{payload.inspect}"
+        end
     end
 
     # @return [DateTime,NilClass] Timestamp of campaign engagement completion if completed
+    # @raise [InvalidPayload] when phone_campaign_state completed_at missing from payload
     def phone_campaign_state_completed_at
       @phone_campaign_state_completed_at ||= begin
-        raw_completed_at = phone_campaign_state_hash.fetch("completed_at")
+        raw_completed_at = phone_campaign_state_hash.fetch("completed_at") do
+          raise InvalidPayload,
+                "phone_campaign_state completed_at missing from payload #{payload.inspect}"
+        end
         DateTime.parse(raw_completed_at).freeze if raw_completed_at
       end
     end
@@ -79,23 +119,24 @@ module SmSmsCampaignWebhook
 
     # @return [Hash] Data from campaign engagement payload
     def payload_data
-      @payload_data ||= payload.fetch("data").freeze
+      @payload_data ||= payload.fetch("data", {}).freeze
     end
 
     # @return [Hash] Campaign hash from payload data
     def campaign_hash
-      @campaign_hash ||= payload_data.fetch("campaign").freeze
+      @campaign_hash ||= payload_data.fetch("campaign", {}).freeze
     end
 
     # @return [Hash] Phone hash from payload data
     def phone_hash
-      @phone_hash ||= payload_data.fetch("phone").freeze
+      @phone_hash ||= payload_data.fetch("phone", {}).freeze
     end
 
     # @return [Hash] Campaign engagement state hash from payload data
     def phone_campaign_state_hash
-      @phone_campaign_state_hash ||= payload_data.fetch("phone_campaign_state")
-                                                 .freeze
+      @phone_campaign_state_hash ||= payload_data
+        .fetch("phone_campaign_state", {})
+        .freeze
     end
   end
 end

--- a/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
+++ b/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
@@ -182,6 +182,14 @@ module SmSmsCampaignWebhook
       end
     end
 
+    # @param field [String] Answer data to find
+    # @return [Answer,NilClass] Serialized answer for field when found
+    def answer_for(field:)
+      phone_campaign_state_answers.detect do |answer|
+        answer.field == field
+      end
+    end
+
     private
 
     # @return [Hash] Data from campaign engagement payload

--- a/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
+++ b/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "date"
+
+module SmSmsCampaignWebhook
+  # Data model for campaign engagement event from SMS campaign.
+  class CampaignEngagement
+    attr_reader :payload
+
+    # @param payload [Hash] Campaign engagement event payload
+    def initialize(payload)
+      @payload = payload.deep_dup
+    end
+
+    # @return [String] Campaign engagement event UUID
+    def event_uuid
+      @event_uuid ||= payload.fetch("uuid")
+    end
+
+    # @return [String] Campaign engagement event type
+    def event_type
+      @event_type ||= payload.fetch("type")
+    end
+
+    # @return [DateTime] Campaign engagement event timestamp
+    def event_created_at
+      @event_created_at ||= begin
+        raw_created_at = payload.fetch("created_at")
+        DateTime.parse(raw_created_at)
+      end
+    end
+
+    # @return [Integer] ID of the engaged campaign
+    def campaign_id
+      @campaign_id ||= campaign_hash.fetch("id")
+    end
+
+    # @return [String] Keyword of the engaged campaign
+    def campaign_keyword
+      @campaign_keyword ||= campaign_hash.fetch("keyword")
+    end
+
+    # @return [String] ID of the engaging phone
+    def phone_id
+      @phone_id ||= phone_hash.fetch("id")
+    end
+
+    # @return [String] Phone number engaging the campaign
+    def phone_number
+      @phone_number ||= phone_hash.fetch("number")
+    end
+
+    # @return [Integer] ID of campaign engagement state record
+    def phone_campaign_state_id
+      @phone_campaign_state_id ||= phone_campaign_state_hash.fetch("id")
+    end
+
+    # @return [TrueClass,FalseClass] Has campaign engagement completed?
+    def phone_campaign_state_completed?
+      # Has the boolean value already been assigned?
+      if !@phone_campaign_state_completed.nil?
+        return @phone_campaign_state_completed
+      end
+
+      # Extract the value and memoize it.
+      @phone_campaign_state_completed = phone_campaign_state_hash
+        .fetch("completed")
+    end
+
+    # @return [DateTime,NilClass] Timestamp of campaign engagement completion if completed
+    def phone_campaign_state_completed_at
+      @phone_campaign_state_completed_at ||= begin
+        raw_completed_at = phone_campaign_state_hash.fetch("completed_at")
+        DateTime.parse(raw_completed_at) if raw_completed_at
+      end
+    end
+
+    private
+
+    # @return [Hash] Data from campaign engagement payload
+    def payload_data
+      @payload_data ||= payload.fetch("data")
+    end
+
+    # @return [Hash] Campaign hash from payload data
+    def campaign_hash
+      @campaign_hash ||= payload_data.fetch("campaign")
+    end
+
+    # @return [Hash] Phone hash from payload data
+    def phone_hash
+      @phone_hash ||= payload_data.fetch("phone")
+    end
+
+    # @return [Hash] Campaign engagement state hash from payload data
+    def phone_campaign_state_hash
+      @phone_campaign_state_hash ||= payload_data.fetch("phone_campaign_state")
+    end
+  end
+end

--- a/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
+++ b/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
@@ -9,24 +9,24 @@ module SmSmsCampaignWebhook
 
     # @param payload [Hash] Campaign engagement event payload
     def initialize(payload)
-      @payload = payload.deep_dup
+      @payload = payload.deep_dup.freeze
     end
 
     # @return [String] Campaign engagement event UUID
     def event_uuid
-      @event_uuid ||= payload.fetch("uuid")
+      @event_uuid ||= payload.fetch("uuid").freeze
     end
 
     # @return [String] Campaign engagement event type
     def event_type
-      @event_type ||= payload.fetch("type")
+      @event_type ||= payload.fetch("type").freeze
     end
 
     # @return [DateTime] Campaign engagement event timestamp
     def event_created_at
       @event_created_at ||= begin
         raw_created_at = payload.fetch("created_at")
-        DateTime.parse(raw_created_at)
+        DateTime.parse(raw_created_at).freeze
       end
     end
 
@@ -37,7 +37,7 @@ module SmSmsCampaignWebhook
 
     # @return [String] Keyword of the engaged campaign
     def campaign_keyword
-      @campaign_keyword ||= campaign_hash.fetch("keyword")
+      @campaign_keyword ||= campaign_hash.fetch("keyword").freeze
     end
 
     # @return [String] ID of the engaging phone
@@ -47,7 +47,7 @@ module SmSmsCampaignWebhook
 
     # @return [String] Phone number engaging the campaign
     def phone_number
-      @phone_number ||= phone_hash.fetch("number")
+      @phone_number ||= phone_hash.fetch("number").freeze
     end
 
     # @return [Integer] ID of campaign engagement state record
@@ -71,7 +71,7 @@ module SmSmsCampaignWebhook
     def phone_campaign_state_completed_at
       @phone_campaign_state_completed_at ||= begin
         raw_completed_at = phone_campaign_state_hash.fetch("completed_at")
-        DateTime.parse(raw_completed_at) if raw_completed_at
+        DateTime.parse(raw_completed_at).freeze if raw_completed_at
       end
     end
 
@@ -79,22 +79,23 @@ module SmSmsCampaignWebhook
 
     # @return [Hash] Data from campaign engagement payload
     def payload_data
-      @payload_data ||= payload.fetch("data")
+      @payload_data ||= payload.fetch("data").freeze
     end
 
     # @return [Hash] Campaign hash from payload data
     def campaign_hash
-      @campaign_hash ||= payload_data.fetch("campaign")
+      @campaign_hash ||= payload_data.fetch("campaign").freeze
     end
 
     # @return [Hash] Phone hash from payload data
     def phone_hash
-      @phone_hash ||= payload_data.fetch("phone")
+      @phone_hash ||= payload_data.fetch("phone").freeze
     end
 
     # @return [Hash] Campaign engagement state hash from payload data
     def phone_campaign_state_hash
       @phone_campaign_state_hash ||= payload_data.fetch("phone_campaign_state")
+                                                 .freeze
     end
   end
 end

--- a/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
+++ b/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
@@ -160,6 +160,28 @@ module SmSmsCampaignWebhook
             "phone_campaign_state completed_at has invalid datetime value #{payload.inspect}"
     end
 
+    # @return [Array<Answer>] Serialized campaign engagement answers
+    # @raise [InvalidPayload] when phone_campaign_state answers missing from payload
+    # @raise [InvalidPayloadValue] when phone_campaign_state answers not hash
+    def phone_campaign_state_answers
+      @phone_campaign_state_answers ||= begin
+        # Extract answers data from payload.
+        data = phone_campaign_state_hash.fetch("answers") do
+          raise InvalidPayload,
+            "phone_campaign_state answers missing from payload #{payload.inspect}"
+        end
+        
+        # Is this hash data?
+        if !data.is_a?(Hash)
+          raise InvalidPayloadValue,
+            "phone_campaign_state answers has invalid hash value #{payload.inspect}"
+        end
+
+        # Serialize answers data.
+        Answer.serialize(data: data).freeze
+      end
+    end
+
     private
 
     # @return [Hash] Data from campaign engagement payload

--- a/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
+++ b/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
@@ -15,19 +15,23 @@ module SmSmsCampaignWebhook
     # @return [String] Campaign engagement event UUID
     # @raise [InvalidPayload] when uuid missing from payload
     def event_uuid
-      @event_uuid ||= payload.fetch("uuid") do
-        raise InvalidPayload,
-              "uuid missing from payload #{payload.inspect}"
-      end.freeze
+      @event_uuid ||= String(
+        payload.fetch("uuid") do
+          raise InvalidPayload,
+                "uuid missing from payload #{payload.inspect}"
+        end.freeze
+      )
     end
 
     # @return [String] Campaign engagement event type
     # @raise [InvalidPayload] when type missing from payload
     def event_type
-      @event_type ||= payload.fetch("type") do
-        raise InvalidPayload,
-              "type missing from payload #{payload.inspect}"
-      end.freeze
+      @event_type ||= String(
+        payload.fetch("type") do
+          raise InvalidPayload,
+                "type missing from payload #{payload.inspect}"
+        end.freeze
+      )
     end
 
     # @return [DateTime] Campaign engagement event timestamp
@@ -54,10 +58,12 @@ module SmSmsCampaignWebhook
     # @return [String] Keyword of the engaged campaign
     # @raise [InvalidPayload] when campaign keyword missing from payload
     def campaign_keyword
-      @campaign_keyword ||= campaign_hash.fetch("keyword") do
-        raise InvalidPayload,
-              "campaign keyword missing from payload #{payload.inspect}"
-      end.freeze
+      @campaign_keyword ||= String(
+        campaign_hash.fetch("keyword") do
+          raise InvalidPayload,
+                "campaign keyword missing from payload #{payload.inspect}"
+        end.freeze
+      )
     end
 
     # @return [Integer] ID of the engaging phone
@@ -72,10 +78,12 @@ module SmSmsCampaignWebhook
     # @return [String] Phone number engaging the campaign
     # @raise [InvalidPayload] when phone number missing from payload
     def phone_number
-      @phone_number ||= phone_hash.fetch("number") do
-        raise InvalidPayload,
-              "phone number missing from payload #{payload.inspect}"
-      end.freeze
+      @phone_number ||= String(
+        phone_hash.fetch("number") do
+          raise InvalidPayload,
+                "phone number missing from payload #{payload.inspect}"
+        end.freeze
+      )
     end
 
     # @return [Integer] ID of campaign engagement state record

--- a/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
+++ b/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
@@ -48,11 +48,17 @@ module SmSmsCampaignWebhook
 
     # @return [Integer] ID of the engaged campaign
     # @raise [InvalidPayload] when campaign id missing from payload
+    # @raise [InvalidPayloadValue] when campaign id not numeric
     def campaign_id
-      @campaign_id ||= campaign_hash.fetch("id") do
-        raise InvalidPayload,
-              "campaign id missing from payload #{payload.inspect}"
-      end
+      @campaign_id ||= Integer(
+        campaign_hash.fetch("id") do
+          raise InvalidPayload,
+                "campaign id missing from payload #{payload.inspect}"
+        end
+      )
+    rescue ArgumentError
+      raise InvalidPayloadValue,
+            "campaign id has invalid integer value #{payload.inspect}"
     end
 
     # @return [String] Keyword of the engaged campaign
@@ -68,11 +74,17 @@ module SmSmsCampaignWebhook
 
     # @return [Integer] ID of the engaging phone
     # @raise [InvalidPayload] when phone id missing from payload
+    # @raise [InvalidPayloadValue] when phone id not numeric
     def phone_id
-      @phone_id ||= phone_hash.fetch("id") do
-        raise InvalidPayload,
-              "phone id missing from payload #{payload.inspect}"
-      end
+      @phone_id ||= Integer(
+        phone_hash.fetch("id") do
+          raise InvalidPayload,
+                "phone id missing from payload #{payload.inspect}"
+        end
+      )
+    rescue ArgumentError
+      raise InvalidPayloadValue,
+            "phone id has invalid integer value #{payload.inspect}"
     end
 
     # @return [String] Phone number engaging the campaign
@@ -88,11 +100,17 @@ module SmSmsCampaignWebhook
 
     # @return [Integer] ID of campaign engagement state record
     # @raise [InvalidPayload] when phone_campaign_state id missing from payload
+    # @raise [InvalidPayloadValue] when phone_campaign_state id not numeric
     def phone_campaign_state_id
-      @phone_campaign_state_id ||= phone_campaign_state_hash.fetch("id") do
-        raise InvalidPayload,
-              "phone_campaign_state id missing from payload #{payload.inspect}"
-      end
+      @phone_campaign_state_id ||= Integer(
+        phone_campaign_state_hash.fetch("id") do
+          raise InvalidPayload,
+                "phone_campaign_state id missing from payload #{payload.inspect}"
+        end
+      )
+    rescue ArgumentError
+      raise InvalidPayloadValue,
+            "phone_campaign_state id has invalid integer value #{payload.inspect}"
     end
 
     # @return [TrueClass,FalseClass] Has campaign engagement completed?

--- a/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
+++ b/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
@@ -60,7 +60,7 @@ module SmSmsCampaignWebhook
       end.freeze
     end
 
-    # @return [String] ID of the engaging phone
+    # @return [Integer] ID of the engaging phone
     # @raise [InvalidPayload] when phone id missing from payload
     def phone_id
       @phone_id ||= phone_hash.fetch("id") do

--- a/app/models/sm_sms_campaign_webhook/campaign_engagement/answer.rb
+++ b/app/models/sm_sms_campaign_webhook/campaign_engagement/answer.rb
@@ -6,6 +6,13 @@ module SmSmsCampaignWebhook
   class CampaignEngagement
     # Data model for campaign engagement answer data.
     class Answer
+      # @return [Array<Answer>] Serialized answer data sorted by collected_at
+      def self.serialize(data:)
+        data.map do |field, answer_hash|
+          new(field: field, answer_hash: answer_hash)
+        end.sort_by(&:collected_at)
+      end
+
       attr_reader :field,
                   :answer_hash
 

--- a/app/models/sm_sms_campaign_webhook/campaign_engagement/answer.rb
+++ b/app/models/sm_sms_campaign_webhook/campaign_engagement/answer.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "date"
+
+module SmSmsCampaignWebhook
+  class CampaignEngagement
+    # Data model for campaign engagement answer data.
+    class Answer
+      attr_reader :field,
+                  :answer_hash
+
+      # @param field [String] Field describing the answer
+      # @param answer_hash [Hash] Answer data from payload
+      def initialize(field:, answer_hash:)
+        @field = String(field)
+        @answer_hash = answer_hash.freeze
+      end
+
+      # Collected answer could be many different value types.
+      #
+      # The SMS campaign service collects answers of type:
+      # string, email, date, number, boolean, us_state
+      #
+      # The possible types are from SMS campaign service perspective.
+      # They are serialized to the appropriate type in Ruby.
+      #
+      # @return [String,Integer,Date,TrueClass,FalseClass] Serialized answer
+      # @raise [InvalidPayload] when value is missing from answer_hash
+      def value
+        # Could be boolean so cannot rely on double pipe assignment guard.
+        if !@value.nil?
+          return @value
+        end
+
+        # Extract the value and memoize it.
+        @value = begin
+         raw_value = answer_hash.fetch("value") do
+           raise InvalidPayload,
+                 "value missing from answer_hash #{answer_hash.inspect}"
+         end.freeze
+
+         # Attempt to parse date value falling back to raw value.
+         Date.strptime(raw_value, "%Y-%m-%d").freeze rescue raw_value
+        end
+      end
+
+      # @return [DateTime] Timestamp of answer value collection
+      # @raise [InvalidPayload] when collected_at missing from answer_hash
+      # @raise [InvalidPayloadValue] when collected_at not datetime
+      def collected_at
+        @collected_at ||= begin
+          raw_collected_at = answer_hash.fetch("collected_at") do
+            raise InvalidPayload,
+                  "collected_at missing from answer_hash #{answer_hash.inspect}"
+          end
+          DateTime.parse(raw_collected_at).freeze
+        end
+      rescue ArgumentError
+        raise InvalidPayloadValue,
+              "collected_at has invalid datetime value #{answer_hash.inspect}"
+      end
+    end
+  end
+end

--- a/lib/sm_sms_campaign_webhook.rb
+++ b/lib/sm_sms_campaign_webhook.rb
@@ -5,6 +5,4 @@ require "sm_sms_campaign_webhook/version"
 
 # Namespace for SMS campaign webhook.
 module SmSmsCampaignWebhook
-  # General base error type for custom errors.
-  class Error < StandardError; end
 end

--- a/spec/models/campaign_engagement/answer_spec.rb
+++ b/spec/models/campaign_engagement/answer_spec.rb
@@ -1,0 +1,212 @@
+require "date"
+require_relative "../../support/helpers/sms_campaign_payload"
+
+RSpec.describe SmSmsCampaignWebhook::CampaignEngagement::Answer, type: :model do
+  include Helpers::SmsCampaignPayload
+
+  let(:field) { payload.keys.first }
+  let(:answer_hash) { payload.fetch(field) }
+  let(:payload) do
+    campaign_engagement_hash.dig(
+      "data",
+      "phone_campaign_state",
+      "answers"
+    )
+  end
+
+  subject do
+    described_class.new(field: field, answer_hash: answer_hash)
+  end
+
+  describe "attributes" do
+    context ":field" do
+      it { should respond_to(:field) }
+      it { should_not respond_to(:field=) }
+    end
+
+    context ":answer_hash" do
+      it { should respond_to(:answer_hash) }
+      it { should_not respond_to(:answer_hash=) }
+    end
+  end
+
+  describe "#initialize" do
+    it "assigns field to @field" do
+      expect(subject.field).to eq(field)
+    end
+
+    it "assigns answer_hash to @answer_hash" do
+      expect(subject.answer_hash).to eq(answer_hash)
+    end
+  end
+
+  describe "#field" do
+    it "freezes the value" do
+      expect(subject.field).to be_frozen
+    end
+  end
+
+  describe "#answer_hash" do
+    it "freezes the value" do
+      expect(subject.answer_hash).to be_frozen
+    end
+  end
+
+  describe "#value" do
+    context "when answer_hash value is missing" do
+      before do
+        answer_hash.delete("value")
+      end
+
+      it "raises an error" do
+        expect do
+          subject.value
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
+    context "when answer_hash value is a string" do
+      before do
+        answer_hash["value"] = "answer string"
+      end
+
+      it "returns answer_hash value as string" do
+        expected_result = answer_hash.fetch("value")
+        expect(subject.value).to eq(expected_result)
+        expect(subject.value).to be_a(String)
+      end
+
+      it "freezes the value" do
+        expect(subject.value).to be_frozen
+      end
+    end
+
+    context "when answer_hash value is an email" do
+      before do
+        answer_hash["value"] = "email@example.com"
+      end
+
+      it "returns answer_hash value as string" do
+        expected_result = answer_hash.fetch("value")
+        expect(subject.value).to eq(expected_result)
+        expect(subject.value).to be_a(String)
+      end
+
+      it "freezes the value" do
+        expect(subject.value).to be_frozen
+      end
+    end
+
+    context "when answer_hash value is a date" do
+      before do
+        answer_hash["value"] = "2000-07-04"
+      end
+
+      it "returns serialized answer_hash value as date" do
+        expected_result = Date.parse(answer_hash.fetch("value"))
+        expect(subject.value).to eq(expected_result)
+      end
+
+      it "freezes the value" do
+        expect(subject.value).to be_frozen
+      end
+    end
+
+    context "when answer_hash value is a number" do
+      before do
+        answer_hash["value"] = 42
+      end
+
+      it "returns answer_hash value as integer" do
+        expected_result = answer_hash.fetch("value")
+        expect(subject.value).to eq(expected_result)
+        expect(subject.value).to be_a(Integer)
+      end
+
+      it "freezes the value" do
+        expect(subject.value).to be_frozen
+      end
+    end
+
+    context "when answer_hash value is boolean" do
+      context "when true" do
+        before do
+          answer_hash["value"] = true
+        end
+
+        it "returns true" do
+          expect(subject.value).to eq(true)
+        end
+
+        it "freezes the value" do
+          expect(subject.value).to be_frozen
+        end
+      end
+
+      context "when false" do
+        before do
+          answer_hash["value"] = false
+        end
+
+        it "returns false" do
+          expect(subject.value).to eq(false)
+        end
+
+        it "freezes the value" do
+          expect(subject.value).to be_frozen
+        end
+      end
+    end
+
+    context "when answer_hash value is us state" do
+      before do
+        answer_hash["value"] = %w[TN FL NY].sample
+      end
+
+      it "returns answer_hash value as string" do
+        expected_result = answer_hash.fetch("value")
+        expect(subject.value).to eq(expected_result)
+        expect(subject.value).to be_a(String)
+      end
+
+      it "freezes the value" do
+        expect(subject.value).to be_frozen
+      end
+    end
+  end
+
+  describe "#collected_at" do
+    context "when answer_hash collected_at is missing" do
+      before do
+        answer_hash.delete("collected_at")
+      end
+
+      it "raises an error" do
+        expect do
+          subject.collected_at
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
+    context "when answer_hash collected_at has unexpected value" do
+      before do
+        answer_hash["collected_at"] = "collected at"
+      end
+
+      it "raises an error" do
+        expect do
+          subject.collected_at
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayloadValue)
+      end
+    end
+
+    it "returns serialized answer_hash collected_at" do
+      expected_result = DateTime.parse(answer_hash.fetch("collected_at"))
+      expect(subject.collected_at).to eq(expected_result)
+    end
+
+    it "freezes the value" do
+      expect(subject.collected_at).to be_frozen
+    end
+  end
+end

--- a/spec/models/campaign_engagement_spec.rb
+++ b/spec/models/campaign_engagement_spec.rb
@@ -23,10 +23,20 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
     end
   end
 
+  describe "#payload" do
+    it "freezes the value" do
+      expect(subject.payload).to be_frozen
+    end
+  end
+
   describe "#event_uuid" do
     it "returns payload uuid" do
       expected_result = payload.fetch("uuid")
       expect(subject.event_uuid).to eq(expected_result)
+    end
+
+    it "freezes the value" do
+      expect(subject.event_uuid).to be_frozen
     end
   end
 
@@ -35,12 +45,20 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
       expected_result = payload.fetch("type")
       expect(subject.event_type).to eq(expected_result)
     end
+
+    it "freezes the value" do
+      expect(subject.event_type).to be_frozen
+    end
   end
 
   describe "#event_created_at" do
     it "returns serialized payload created_at" do
       expected_value = DateTime.parse(payload.fetch("created_at"))
       expect(subject.event_created_at).to eq(expected_value)
+    end
+
+    it "freezes the value" do
+      expect(subject.event_created_at).to be_frozen
     end
   end
 
@@ -49,12 +67,20 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
       expected_result = payload.dig("data", "campaign", "id")
       expect(subject.campaign_id).to eq(expected_result)
     end
+
+    it "freezes the value" do
+      expect(subject.campaign_id).to be_frozen
+    end
   end
 
   describe "#campaign_keyword" do
     it "returns payload data campaign keyword" do
       expected_result = payload.dig("data", "campaign", "keyword")
       expect(subject.campaign_keyword).to eq(expected_result)
+    end
+
+    it "freezes the value" do
+      expect(subject.campaign_keyword).to be_frozen
     end
   end
 
@@ -63,6 +89,10 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
       expected_result = payload.dig("data", "phone", "id")
       expect(subject.phone_id).to eq(expected_result)
     end
+
+    it "freezes the value" do
+      expect(subject.phone_id).to be_frozen
+    end
   end
 
   describe "#phone_number" do
@@ -70,12 +100,20 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
       expected_result = payload.dig("data", "phone", "number")
       expect(subject.phone_number).to eq(expected_result)
     end
+
+    it "freezes the value" do
+      expect(subject.phone_number).to be_frozen
+    end
   end
 
   describe "#phone_campaign_state_id" do
     it "returns payload data phone_campaign_state id" do
       expected_result = payload.dig("data", "phone_campaign_state", "id")
       expect(subject.phone_campaign_state_id).to eq(expected_result)
+    end
+
+    it "freezes the value" do
+      expect(subject.phone_campaign_state_id).to be_frozen
     end
   end
 
@@ -101,6 +139,10 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
         expect(subject.phone_campaign_state_completed?).to eq(true)
       end
     end
+
+    it "freezes the value" do
+      expect(subject.phone_campaign_state_completed?).to be_frozen
+    end
   end
 
   describe "#phone_campaign_state_completed_at" do
@@ -124,6 +166,10 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
           payload.dig("data", "phone_campaign_state", "completed_at")
         )
         expect(subject.phone_campaign_state_completed_at).to eq(expected_result)
+      end
+
+      it "freezes the value" do
+        expect(subject.phone_campaign_state_completed_at).to be_frozen
       end
     end
   end

--- a/spec/models/campaign_engagement_spec.rb
+++ b/spec/models/campaign_engagement_spec.rb
@@ -363,4 +363,42 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
       end
     end
   end
+
+  describe "#phone_campaign_state_answers" do
+    context "when phone_campaign_state answers is missing" do
+      before do
+        payload["data"]["phone_campaign_state"].delete("answers")
+      end
+
+      it "raises an error" do
+        expect do
+          subject.phone_campaign_state_answers
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
+    context "when phone_campaign_state answers has unexpected value" do
+      before do
+        payload["data"]["phone_campaign_state"]["answers"] = "answers"
+      end
+
+      it "raises an error" do
+        expect do
+          subject.phone_campaign_state_answers
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayloadValue)
+      end
+    end
+
+    it "returns serialized phone_campaign_state answers" do
+      result = subject.phone_campaign_state_answers
+      expect(result).to be_a(Array)
+      result.each do |serialized_answer|
+        expect(serialized_answer).to be_a(described_class::Answer)
+      end
+    end
+
+    it "freezes the value" do
+      expect(subject.phone_campaign_state_answers).to be_frozen
+    end
+  end
 end

--- a/spec/models/campaign_engagement_spec.rb
+++ b/spec/models/campaign_engagement_spec.rb
@@ -1,0 +1,130 @@
+require "date"
+require_relative "../support/helpers/sms_campaign_payload"
+
+RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
+  include Helpers::SmsCampaignPayload
+
+  let(:payload) do
+    campaign_engagement_hash
+  end
+
+  subject { described_class.new(payload) }
+
+  describe "attributes" do
+    context ":payload" do
+      it { should respond_to(:payload) }
+      it { should_not respond_to(:payload=) }
+    end
+  end
+
+  describe "#initialize" do
+    it "assigns param to @payload" do
+      expect(subject.payload).to eq(payload)
+    end
+  end
+
+  describe "#event_uuid" do
+    it "returns payload uuid" do
+      expected_result = payload.fetch("uuid")
+      expect(subject.event_uuid).to eq(expected_result)
+    end
+  end
+
+  describe "#event_type" do
+    it "returns payload type" do
+      expected_result = payload.fetch("type")
+      expect(subject.event_type).to eq(expected_result)
+    end
+  end
+
+  describe "#event_created_at" do
+    it "returns serialized payload created_at" do
+      expected_value = DateTime.parse(payload.fetch("created_at"))
+      expect(subject.event_created_at).to eq(expected_value)
+    end
+  end
+
+  describe "#campaign_id" do
+    it "returns payload data campaign id" do
+      expected_result = payload.dig("data", "campaign", "id")
+      expect(subject.campaign_id).to eq(expected_result)
+    end
+  end
+
+  describe "#campaign_keyword" do
+    it "returns payload data campaign keyword" do
+      expected_result = payload.dig("data", "campaign", "keyword")
+      expect(subject.campaign_keyword).to eq(expected_result)
+    end
+  end
+
+  describe "#phone_id" do
+    it "returns payload data phone id" do
+      expected_result = payload.dig("data", "phone", "id")
+      expect(subject.phone_id).to eq(expected_result)
+    end
+  end
+
+  describe "#phone_number" do
+    it "returns payload data phone number" do
+      expected_result = payload.dig("data", "phone", "number")
+      expect(subject.phone_number).to eq(expected_result)
+    end
+  end
+
+  describe "#phone_campaign_state_id" do
+    it "returns payload data phone_campaign_state id" do
+      expected_result = payload.dig("data", "phone_campaign_state", "id")
+      expect(subject.phone_campaign_state_id).to eq(expected_result)
+    end
+  end
+
+  describe "#phone_campaign_state_answers"
+
+  describe "#phone_campaign_state_completed?" do
+    context "when phone_campaign_state completed is false" do
+      let(:payload) do
+        campaign_engagement_hash(completed: false)
+      end
+
+      it "returns false" do
+        expect(subject.phone_campaign_state_completed?).to eq(false)
+      end
+    end
+
+    context "when phone_campaign_state completed is true" do
+      let(:payload) do
+        campaign_engagement_hash(completed: true)
+      end
+
+      it "returns true" do
+        expect(subject.phone_campaign_state_completed?).to eq(true)
+      end
+    end
+  end
+
+  describe "#phone_campaign_state_completed_at" do
+    context "when phone_campaign_state completed_at is not present" do
+      let(:payload) do
+        campaign_engagement_hash(completed: false)
+      end
+
+      it "returns nil" do
+        expect(subject.phone_campaign_state_completed_at).to be_nil
+      end
+    end
+
+    context "when phone_campaign_state completed_at is present" do
+      let(:payload) do
+        campaign_engagement_hash(completed: true)
+      end
+
+      it "returns serialized payload data phone_campaign_state completed_at" do
+        expected_result = DateTime.parse(
+          payload.dig("data", "phone_campaign_state", "completed_at")
+        )
+        expect(subject.phone_campaign_state_completed_at).to eq(expected_result)
+      end
+    end
+  end
+end

--- a/spec/models/campaign_engagement_spec.rb
+++ b/spec/models/campaign_engagement_spec.rb
@@ -264,6 +264,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
   describe "#phone_campaign_state_answers"
 
   describe "#phone_campaign_state_completed?" do
+    context "when payload data phone_campaign_state completed has unexpected value" do
+      before do
+        payload["data"]["phone_campaign_state"]["completed"] = "completed"
+      end
+
+      it "raises an error" do
+        expect do
+          subject.phone_campaign_state_completed?
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayloadValue)
+      end
+    end
+
     context "when payload data phone_campaign_state completed is missing" do
       before do
         payload["data"]["phone_campaign_state"].delete("completed")

--- a/spec/models/campaign_engagement_spec.rb
+++ b/spec/models/campaign_engagement_spec.rb
@@ -401,4 +401,36 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
       expect(subject.phone_campaign_state_answers).to be_frozen
     end
   end
+
+  describe "#answer_for" do
+    let(:field) do
+      payload
+        .dig(
+          "data",
+          "phone_campaign_state",
+          "answers"
+        )
+        .keys
+        .first
+    end
+
+    context "when answer for field is not found" do
+      it "returns nil" do
+        expect(
+          subject.answer_for(field: "other_#{field}")
+        ).to be_nil
+      end
+    end
+
+    context "when answer for field is found" do
+      it "returns serialized answer" do
+        expected_result = subject.phone_campaign_state_answers.detect do |answer|
+          answer.field == field
+        end
+        expect(
+          subject.answer_for(field: field)
+        ).to eq(expected_result)
+      end
+    end
+  end
 end

--- a/spec/models/campaign_engagement_spec.rb
+++ b/spec/models/campaign_engagement_spec.rb
@@ -111,6 +111,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
       end
     end
 
+    context "when payload data campaign id has unexpected value" do
+      before do
+        payload["data"]["campaign"]["id"] = "campaign id"
+      end
+
+      it "raises an error" do
+        expect do
+          subject.campaign_id
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayloadValue)
+      end
+    end
+
     it "returns payload data campaign id" do
       expected_result = payload.dig("data", "campaign", "id")
       expect(subject.campaign_id).to eq(expected_result)
@@ -157,6 +169,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
       end
     end
 
+    context "when payload data phone id has unexpected value" do
+      before do
+        payload["data"]["phone"]["id"] = "phone id"
+      end
+
+      it "raises an error" do
+        expect do
+          subject.phone_id
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayloadValue)
+      end
+    end
+
     it "returns payload data phone id" do
       expected_result = payload.dig("data", "phone", "id")
       expect(subject.phone_id).to eq(expected_result)
@@ -200,6 +224,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
         expect do
           subject.phone_campaign_state_id
         end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
+    context "when payload data phone_campaign_state id has unexpected value" do
+      before do
+        payload["data"]["phone_campaign_state"]["id"] = "phone_campaign_state id"
+      end
+
+      it "raises an error" do
+        expect do
+          subject.phone_campaign_state_id
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayloadValue)
       end
     end
 

--- a/spec/models/campaign_engagement_spec.rb
+++ b/spec/models/campaign_engagement_spec.rb
@@ -30,6 +30,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
   end
 
   describe "#event_uuid" do
+    context "when payload uuid is missing" do
+      before do
+        payload.delete("uuid")
+      end
+
+      it "raises an error" do
+        expect do
+          subject.event_uuid
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
     it "returns payload uuid" do
       expected_result = payload.fetch("uuid")
       expect(subject.event_uuid).to eq(expected_result)
@@ -41,6 +53,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
   end
 
   describe "#event_type" do
+    context "when payload type is missing" do
+      before do
+        payload.delete("type")
+      end
+
+      it "raises an error" do
+        expect do
+          subject.event_type
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
     it "returns payload type" do
       expected_result = payload.fetch("type")
       expect(subject.event_type).to eq(expected_result)
@@ -52,6 +76,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
   end
 
   describe "#event_created_at" do
+    context "when payload created_at is missing" do
+      before do
+        payload.delete("created_at")
+      end
+
+      it "raises an error" do
+        expect do
+          subject.event_created_at
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
     it "returns serialized payload created_at" do
       expected_value = DateTime.parse(payload.fetch("created_at"))
       expect(subject.event_created_at).to eq(expected_value)
@@ -63,6 +99,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
   end
 
   describe "#campaign_id" do
+    context "when payload data campaign id is missing" do
+      before do
+        payload["data"]["campaign"].delete("id")
+      end
+
+      it "raises an error" do
+        expect do
+          subject.campaign_id
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
     it "returns payload data campaign id" do
       expected_result = payload.dig("data", "campaign", "id")
       expect(subject.campaign_id).to eq(expected_result)
@@ -74,6 +122,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
   end
 
   describe "#campaign_keyword" do
+    context "when payload data campaign keyword is missing" do
+      before do
+        payload["data"]["campaign"].delete("keyword")
+      end
+
+      it "raises an error" do
+        expect do
+          subject.campaign_keyword
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
     it "returns payload data campaign keyword" do
       expected_result = payload.dig("data", "campaign", "keyword")
       expect(subject.campaign_keyword).to eq(expected_result)
@@ -85,6 +145,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
   end
 
   describe "#phone_id" do
+    context "when payload data phone id is missing" do
+      before do
+        payload["data"]["phone"].delete("id")
+      end
+
+      it "raises an error" do
+        expect do
+          subject.phone_id
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
     it "returns payload data phone id" do
       expected_result = payload.dig("data", "phone", "id")
       expect(subject.phone_id).to eq(expected_result)
@@ -96,6 +168,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
   end
 
   describe "#phone_number" do
+    context "when payload data phone number is missing" do
+      before do
+        payload["data"]["phone"].delete("number")
+      end
+
+      it "raises an error" do
+        expect do
+          subject.phone_number
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
     it "returns payload data phone number" do
       expected_result = payload.dig("data", "phone", "number")
       expect(subject.phone_number).to eq(expected_result)
@@ -107,6 +191,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
   end
 
   describe "#phone_campaign_state_id" do
+    context "when payload data phone_campaign_state id is missing" do
+      before do
+        payload["data"]["phone_campaign_state"].delete("id")
+      end
+
+      it "raises an error" do
+        expect do
+          subject.phone_campaign_state_id
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
     it "returns payload data phone_campaign_state id" do
       expected_result = payload.dig("data", "phone_campaign_state", "id")
       expect(subject.phone_campaign_state_id).to eq(expected_result)
@@ -120,6 +216,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
   describe "#phone_campaign_state_answers"
 
   describe "#phone_campaign_state_completed?" do
+    context "when payload data phone_campaign_state completed is missing" do
+      before do
+        payload["data"]["phone_campaign_state"].delete("completed")
+      end
+
+      it "raises an error" do
+        expect do
+          subject.phone_campaign_state_completed?
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
     context "when phone_campaign_state completed is false" do
       let(:payload) do
         campaign_engagement_hash(completed: false)
@@ -146,6 +254,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
   end
 
   describe "#phone_campaign_state_completed_at" do
+    context "when payload data phone_campaign_state completed_at is missing" do
+      before do
+        payload["data"]["phone_campaign_state"].delete("completed_at")
+      end
+
+      it "raises an error" do
+        expect do
+          subject.phone_campaign_state_completed_at
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
     context "when phone_campaign_state completed_at is not present" do
       let(:payload) do
         campaign_engagement_hash(completed: false)

--- a/spec/models/campaign_engagement_spec.rb
+++ b/spec/models/campaign_engagement_spec.rb
@@ -261,8 +261,6 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
     end
   end
 
-  describe "#phone_campaign_state_answers"
-
   describe "#phone_campaign_state_completed?" do
     context "when payload data phone_campaign_state completed has unexpected value" do
       before do

--- a/spec/models/campaign_engagement_spec.rb
+++ b/spec/models/campaign_engagement_spec.rb
@@ -88,6 +88,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
       end
     end
 
+    context "when payload created_at has unexpected value" do
+      before do
+        payload["created_at"] = "created at"
+      end
+
+      it "raises an error" do
+        expect do
+          subject.event_created_at
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayloadValue)
+      end
+    end
+
     it "returns serialized payload created_at" do
       expected_value = DateTime.parse(payload.fetch("created_at"))
       expect(subject.event_created_at).to eq(expected_value)
@@ -299,6 +311,18 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
         expect do
           subject.phone_campaign_state_completed_at
         end.to raise_error(SmSmsCampaignWebhook::InvalidPayload)
+      end
+    end
+
+    context "when payload data phone_campaign_state completed_at has unexpected value" do
+      before do
+        payload["data"]["phone_campaign_state"]["completed_at"] = "completed at"
+      end
+
+      it "raises an error" do
+        expect do
+          subject.phone_campaign_state_completed_at
+        end.to raise_error(SmSmsCampaignWebhook::InvalidPayloadValue)
       end
     end
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,0 +1,3 @@
+# Namespace for spec helpers.
+module Helpers
+end

--- a/spec/support/helpers/sms_campaign_payload.rb
+++ b/spec/support/helpers/sms_campaign_payload.rb
@@ -1,0 +1,37 @@
+require "securerandom"
+
+module Helpers
+  # Helpers to provide sample SMS campaign payloads.
+  module SmsCampaignPayload
+    # @return [String] Campaign engagement payload as JSON
+    def campaign_engagement_json(completed: false)
+      {
+        uuid: SecureRandom.uuid,
+        object: "event",
+        type: "campaign.engagement",
+        created_at: Time.zone.now,
+        data: {
+          campaign: {
+            id: rand(1..100),
+            keyword: "KEYWORD"
+          },
+          phone: {
+            id: rand(1..100),
+            number: "3335557777"
+          },
+          phone_campaign_state: {
+            id: rand(1..100),
+            answers: {},
+            completed: completed,
+            completed_at: (completed ? Time.zone.now : nil)
+          }
+        }
+      }.to_json
+    end
+
+    # @return [Hash] Campaign engagement payload serialized JSON
+    def campaign_engagement_hash(completed: false)
+      JSON.parse(campaign_engagement_json(completed: completed))
+    end
+  end
+end

--- a/spec/support/helpers/sms_campaign_payload.rb
+++ b/spec/support/helpers/sms_campaign_payload.rb
@@ -4,7 +4,7 @@ module Helpers
   # Helpers to provide sample SMS campaign payloads.
   module SmsCampaignPayload
     # @return [String] Campaign engagement payload as JSON
-    def campaign_engagement_json(completed: false)
+    def campaign_engagement_json(completed: false, total_answers: 1)
       {
         uuid: SecureRandom.uuid,
         object: "event",
@@ -21,20 +21,7 @@ module Helpers
           },
           phone_campaign_state: {
             id: rand(1..100),
-            answers: {
-              field: {
-                value: [
-                  "answer string",
-                  "email@example.com",
-                  "2000-07-04",
-                  42,
-                  true,
-                  false,
-                  "TN"
-                ].sample,
-                collected_at: Time.zone.now
-              }
-            },
+            answers: generate_answers_hash(total_answers),
             completed: completed,
             completed_at: (completed ? Time.zone.now : nil)
           }
@@ -43,8 +30,44 @@ module Helpers
     end
 
     # @return [Hash] Campaign engagement payload serialized JSON
-    def campaign_engagement_hash(completed: false)
-      JSON.parse(campaign_engagement_json(completed: completed))
+    def campaign_engagement_hash(completed: false, total_answers: 1)
+      JSON.parse(
+        campaign_engagement_json(
+          completed: completed,
+          total_answers: total_answers
+        )
+      )
+    end
+
+    private
+
+    # @param total_entries [Integer]
+    # @return [Hash]
+    def generate_answers_hash(total_entries)
+      Hash[
+        (1..total_entries)
+          .to_a
+          .map do |num|
+            ["field#{num}", generate_answer_hash]
+          end
+      ]
+    end
+
+    # @return [Hash]
+    def generate_answer_hash
+      collection_buffer = (1..30).to_a.sample
+      {
+        value: [
+          "answer string",
+          "email@example.com",
+          "2000-07-04",
+          42,
+          true,
+          false,
+          "TN"
+        ].sample,
+        collected_at: Time.zone.now - collection_buffer.seconds
+      }
     end
   end
 end

--- a/spec/support/helpers/sms_campaign_payload.rb
+++ b/spec/support/helpers/sms_campaign_payload.rb
@@ -21,7 +21,20 @@ module Helpers
           },
           phone_campaign_state: {
             id: rand(1..100),
-            answers: {},
+            answers: {
+              field: {
+                value: [
+                  "answer string",
+                  "email@example.com",
+                  "2000-07-04",
+                  42,
+                  true,
+                  false,
+                  "TN"
+                ].sample,
+                collected_at: Time.zone.now
+              }
+            },
             completed: completed,
             completed_at: (completed ? Time.zone.now : nil)
           }


### PR DESCRIPTION
This completes #10. It includes:

* Adding `CampaignEngagement` + `CampaignEngagement::Answer` data models
* Moves custom errors to `app/exceptions/sm_sms_campaign_webhook`
* Lazy payload schema + value type validations
* Helper method for implementors to find specific campaign engagement answers
* Deep copies original payload hash to ensure that it does not modify the payload data
* Freeze all the things to try and make data model instances immutable