### PR TITLE
Update webhook action to cast deserialized payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Mountable Rails engine as API
-- POST /api/webhook resource
+- POST /api/webhook resource requiring JSON payload handing of data modeling
 - Support for Rails 5.2.x, 6.0.x
 - Data models for campaign engagement event payloads
 - Helper method to get specific campaign engagement answer
+- Payload operation library to cast deserialized JSON with supported event data modeling
 
 ### Changed
 - Require Ruby >= 2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mountable Rails engine as API
 - POST /api/webhook resource
 - Support for Rails 5.2.x, 6.0.x
-- Data models to serialize campaign engagement event payloads
+- Data models for campaign engagement event payloads
 - Helper method to get specific campaign engagement answer
 
 ### Changed

--- a/app/controllers/sm_sms_campaign_webhook/webhook_controller.rb
+++ b/app/controllers/sm_sms_campaign_webhook/webhook_controller.rb
@@ -6,8 +6,19 @@ module SmSmsCampaignWebhook
   # API webhook for POST requests from SMS campaign service.
   class WebhookController < ApplicationController
     # POST /api/webhook
+    # @see PayloadOperation.cast
     def create
+      # Deserialize the payload.
+      payload = JSON.parse(request.body.read)
+      logger.debug "#{self.class} - Payload: #{payload.inspect}"
+
+      # Cast the payload data with the appropriate data model.
+      PayloadOperation.cast(payload: payload)
+
       head :no_content
+    rescue JSON::ParserError => e
+      logger.warn "#{self.class} - Bad Request: #{e.class} - #{e}"
+      head :bad_request
     end
   end
 end

--- a/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
+++ b/app/models/sm_sms_campaign_webhook/campaign_engagement.rb
@@ -160,7 +160,7 @@ module SmSmsCampaignWebhook
             "phone_campaign_state completed_at has invalid datetime value #{payload.inspect}"
     end
 
-    # @return [Array<Answer>] Serialized campaign engagement answers
+    # @return [Array<Answer>] Modeled campaign engagement answers
     # @raise [InvalidPayload] when phone_campaign_state answers missing from payload
     # @raise [InvalidPayloadValue] when phone_campaign_state answers not hash
     def phone_campaign_state_answers
@@ -177,13 +177,13 @@ module SmSmsCampaignWebhook
             "phone_campaign_state answers has invalid hash value #{payload.inspect}"
         end
 
-        # Serialize answers data.
-        Answer.serialize(data: data).freeze
+        # Cast answers data.
+        Answer.cast(data: data).freeze
       end
     end
 
     # @param field [String] Answer data to find
-    # @return [Answer,NilClass] Serialized answer for field when found
+    # @return [Answer,NilClass] Modeled answer for field when found
     def answer_for(field:)
       phone_campaign_state_answers.detect do |answer|
         answer.field == field

--- a/app/models/sm_sms_campaign_webhook/campaign_engagement/answer.rb
+++ b/app/models/sm_sms_campaign_webhook/campaign_engagement/answer.rb
@@ -7,8 +7,8 @@ module SmSmsCampaignWebhook
     # Data model for campaign engagement answer data.
     class Answer
       # @param data [Hash] Answers from payload
-      # @return [Array<Answer>] Serialized answer data sorted by collected_at
-      def self.serialize(data:)
+      # @return [Array<Answer>] Modeled answer data sorted by collected_at
+      def self.cast(data:)
         data.map do |field, answer_hash|
           new(field: field, answer_hash: answer_hash)
         end.sort_by(&:collected_at)
@@ -30,9 +30,9 @@ module SmSmsCampaignWebhook
       # string, email, date, number, boolean, us_state
       #
       # The possible types are from SMS campaign service perspective.
-      # They are serialized to the appropriate type in Ruby.
+      # They are coerced to the appropriate type in Ruby.
       #
-      # @return [String,Integer,Date,TrueClass,FalseClass] Serialized answer
+      # @return [String,Integer,Date,TrueClass,FalseClass] Coerced answer
       # @raise [InvalidPayload] when value is missing from answer_hash
       def value
         # Could be boolean so cannot rely on double pipe assignment guard.

--- a/app/operations/sm_sms_campaign_webhook/payload_operation.rb
+++ b/app/operations/sm_sms_campaign_webhook/payload_operation.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module SmSmsCampaignWebhook
+  # Handles payload data modeling and data processing.
+  class PayloadOperation
+    # @param payload [Hash] Deserialized payload from SMS campaign service
+    # @return [CampaignEngagement,NilClass] modeled payload for supported types
+    # @see CampaignEngagement
+    def self.cast(payload:)
+      case payload.fetch("type", "unknown")
+      when "campaign.engagement"
+        CampaignEngagement.new(payload: payload)
+      else
+        # NOOP - Unsupported event type.
+      end
+    end
+  end
+end

--- a/spec/models/campaign_engagement/answer_spec.rb
+++ b/spec/models/campaign_engagement/answer_spec.rb
@@ -4,11 +4,11 @@ require_relative "../../support/helpers/sms_campaign_payload"
 RSpec.describe SmSmsCampaignWebhook::CampaignEngagement::Answer, type: :model do
   include Helpers::SmsCampaignPayload
 
-  describe ".serialize" do
+  describe ".cast" do
     context "when :data param is not present" do
       it "raises an error" do
         expect do
-          described_class.serialize
+          described_class.cast
         end.to raise_error(ArgumentError)
       end
     end
@@ -18,7 +18,7 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement::Answer, type: :model do
 
       it "returns an empty array" do
         expect(
-          described_class.serialize(data: data)
+          described_class.cast(data: data)
         ).to eq([])
       end
     end
@@ -32,8 +32,8 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement::Answer, type: :model do
         )
       end
 
-      it "returns array with serialized answer" do
-        result = described_class.serialize(data: data)
+      it "returns array with modeled answer" do
+        result = described_class.cast(data: data)
         expect(result).to be_a(Array)
         expect(result.length).to eq(1)
         expect(result[0]).to be_a(described_class)
@@ -49,8 +49,8 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement::Answer, type: :model do
         )
       end
 
-      it "returns array with serialized answers sorted by collected_at" do
-        result = described_class.serialize(data: data)
+      it "returns array with modeled answers sorted by collected_at" do
+        result = described_class.cast(data: data)
         expect(result).to be_a(Array)
         expect(result.length).to eq(3)
         expect(result[0]).to be_a(described_class)
@@ -195,7 +195,7 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement::Answer, type: :model do
         answer_hash["value"] = "2000-07-04"
       end
 
-      it "returns serialized answer_hash value as date" do
+      it "returns coerced answer_hash value as date" do
         expected_result = Date.parse(answer_hash.fetch("value"))
         expect(subject.value).to eq(expected_result)
       end
@@ -293,7 +293,7 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement::Answer, type: :model do
       end
     end
 
-    it "returns serialized answer_hash collected_at" do
+    it "returns coerced answer_hash collected_at" do
       expected_result = DateTime.parse(answer_hash.fetch("collected_at"))
       expect(subject.collected_at).to eq(expected_result)
     end

--- a/spec/models/campaign_engagement_spec.rb
+++ b/spec/models/campaign_engagement_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
       end
     end
 
-    it "returns serialized payload created_at" do
+    it "returns coerced payload created_at" do
       expected_value = DateTime.parse(payload.fetch("created_at"))
       expect(subject.event_created_at).to eq(expected_value)
     end
@@ -359,7 +359,7 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
         campaign_engagement_hash(completed: true)
       end
 
-      it "returns serialized payload data phone_campaign_state completed_at" do
+      it "returns coerced payload data phone_campaign_state completed_at" do
         expected_result = DateTime.parse(
           payload.dig("data", "phone_campaign_state", "completed_at")
         )
@@ -397,11 +397,11 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
       end
     end
 
-    it "returns serialized phone_campaign_state answers" do
+    it "returns modeled phone_campaign_state answers" do
       result = subject.phone_campaign_state_answers
       expect(result).to be_a(Array)
-      result.each do |serialized_answer|
-        expect(serialized_answer).to be_a(described_class::Answer)
+      result.each do |modeled_answer|
+        expect(modeled_answer).to be_a(described_class::Answer)
       end
     end
 
@@ -439,7 +439,7 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagement, type: :model do
     end
 
     context "when answer for field is found" do
-      it "returns serialized answer" do
+      it "returns modeled answer" do
         expected_result = subject.phone_campaign_state_answers.detect do |answer|
           answer.field == field
         end

--- a/spec/operations/payload_operation_spec.rb
+++ b/spec/operations/payload_operation_spec.rb
@@ -1,0 +1,62 @@
+require_relative "../support/helpers/sms_campaign_payload"
+
+RSpec.describe SmSmsCampaignWebhook::PayloadOperation do
+  include Helpers::SmsCampaignPayload
+
+  describe ".cast" do
+    let(:method_params) do
+      {
+        payload: payload
+      }
+    end
+    let(:payload) do
+      unsupported_event_hash
+    end
+
+    context "when :payload param is not present" do
+      before do
+        method_params.delete(:payload)
+      end
+
+      it "raises an error" do
+        expect do
+          described_class.cast(method_params)
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    context "when payload is for campaign engagement" do
+      let(:payload) do
+        campaign_engagement_hash
+      end
+
+      it "returns payload modeled as campaign engagement" do
+        expect(
+          described_class.cast(method_params)
+        ).to be_a(SmSmsCampaignWebhook::CampaignEngagement)
+      end
+    end
+
+    context "when payload is for unsupported event" do
+      let(:payload) do
+        unsupported_event_hash
+      end
+
+      it "returns nil" do
+        expect(
+          described_class.cast(method_params)
+        ).to be_nil
+      end
+    end
+
+    context "when payload does not specify type" do
+      let(:payload) { Hash.new }
+
+      it "returns nil" do
+        expect(
+          described_class.cast(method_params)
+        ).to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/api_webhook_spec.rb
+++ b/spec/requests/api_webhook_spec.rb
@@ -1,6 +1,73 @@
+require_relative "../support/helpers/sms_campaign_payload"
+
 RSpec.describe "API webhook", type: :request do
-  it "responds wtih success" do
-    post "/sms_campaign/api/webhook"
-    expect(response).to have_http_status(:no_content)
+  include Helpers::SmsCampaignPayload
+
+  let(:headers) do
+    {
+      "Content-Type" => "application/json",
+      "Accept" => "application/json"
+    }
+  end
+
+  context "without any payload" do
+    it "responds with bad request" do
+      post "/sms_campaign/api/webhook", headers: headers
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  context "without json payload" do
+    let(:headers) do
+      {
+        "Accept" => "*/*"
+      }
+    end
+    let(:payload) do
+      {q: "not json"}
+    end
+
+    it "responds with bad request" do
+      post "/sms_campaign/api/webhook", headers: headers, params: payload
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  context "with unsupported payload" do
+    let(:payload) do
+      unsupported_event_json
+    end
+
+    it "models the payload" do
+      payload_hash = JSON.parse(payload)
+      expect(
+        SmSmsCampaignWebhook::PayloadOperation
+      ).to receive(:cast).with(payload: payload_hash)
+      post "/sms_campaign/api/webhook", headers: headers, params: payload
+    end
+
+    it "responds with success" do
+      post "/sms_campaign/api/webhook", headers: headers, params: payload
+      expect(response).to have_http_status(:no_content)
+    end
+  end
+
+  context "with campaign engagement payload" do
+    let(:payload) do
+      campaign_engagement_json
+    end
+
+    it "models the payload" do
+      payload_hash = JSON.parse(payload)
+      expect(
+        SmSmsCampaignWebhook::PayloadOperation
+      ).to receive(:cast).with(payload: payload_hash)
+      post "/sms_campaign/api/webhook", headers: headers, params: payload
+    end
+
+    it "responds with success" do
+      post "/sms_campaign/api/webhook", headers: headers, params: payload
+      expect(response).to have_http_status(:no_content)
+    end
   end
 end

--- a/spec/support/helpers/sms_campaign_payload.rb
+++ b/spec/support/helpers/sms_campaign_payload.rb
@@ -3,6 +3,21 @@ require "securerandom"
 module Helpers
   # Helpers to provide sample SMS campaign payloads.
   module SmsCampaignPayload
+    # @return [String] Unsupported payload as JSON
+    def unsupported_event_json
+      {
+        uuid: SecureRandom.uuid,
+        object: "event",
+        type: "unsupported",
+        created_at: Time.zone.now
+      }.to_json
+    end
+
+    # @return [Hash] Unsupported payload deserialized from JSON
+    def unsupported_event_hash
+      JSON.parse(unsupported_event_json)
+    end
+
     # @return [String] Campaign engagement payload as JSON
     def campaign_engagement_json(completed: false, total_answers: 1)
       {

--- a/spec/support/helpers/sms_campaign_payload.rb
+++ b/spec/support/helpers/sms_campaign_payload.rb
@@ -44,7 +44,7 @@ module Helpers
       }.to_json
     end
 
-    # @return [Hash] Campaign engagement payload serialized JSON
+    # @return [Hash] Campaign engagement payload deserialized from JSON
     def campaign_engagement_hash(completed: false, total_answers: 1)
       JSON.parse(
         campaign_engagement_json(


### PR DESCRIPTION
These commits close #11. This includes:

* Add `PayloadOperation` lib that casts deserialized JSON to supported data model
* Updating `/api/webhook` action to
  * deserialize JSON payloads
  * hand of data modeling to `PayloadOperation` lib
* Refactor serialization language to modeling + coercion language

I have been misusing serialization + deserialization for who knows how long. I updated code points to try and use the language appropriately moving forward. 🤦‍♂ 