### PR TITLE
Support implementors hooking into payload processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Helper method to get specific campaign engagement answer
 - Payload operation library to dispatch and process deserialized JSON with supported event data modeling
 - Processable behavior definition for app implementors
-- Default processor with NOOP data processing
+- Default processor mixing in processable behavior with noisy errors
 - ActiveJob library for asynchronous handling of payload dispatching and processing
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Data models for campaign engagement event payloads
 - Helper method to get specific campaign engagement answer
 - Payload operation library to dispatch and process deserialized JSON with supported event data modeling
+- Processable behavior definition for app implementors
+- Default processor with NOOP data processing
 - ActiveJob library for asynchronous handling of payload dispatching and processing
 
 ### Changed

--- a/app/operations/sm_sms_campaign_webhook/campaign_engagement_operation.rb
+++ b/app/operations/sm_sms_campaign_webhook/campaign_engagement_operation.rb
@@ -3,9 +3,12 @@
 module SmSmsCampaignWebhook
   # Handles campaign engagement payload data modeling and processing.
   class CampaignEngagementOperation
+    # Models the campaign engagement payload and hands of processing
+    # of the data to the processor.
+    #
     # @param payload [Hash] Deserialized SMS campaign engagement payload
-    # @return [CampaignEngagement] modeled payload
     # @raise [PayloadDispatchError] when not campaign engagement payload
+    # @see .processor
     def self.process(payload:)
       logger.debug "#{name} - Processing campaign engagement payload: #{payload.inspect}"
 
@@ -14,7 +17,8 @@ module SmSmsCampaignWebhook
               "dispatched payload different from campaign.engagement #{payload.inspect}"
       end
 
-      CampaignEngagement.new(payload: payload)
+      campaign_enagement = CampaignEngagement.new(payload: payload)
+      processor.process_campaign_engagement(campaign_enagement)
     end
 
     # @return [Processable] SMS campaign payload processor

--- a/app/operations/sm_sms_campaign_webhook/campaign_engagement_operation.rb
+++ b/app/operations/sm_sms_campaign_webhook/campaign_engagement_operation.rb
@@ -17,6 +17,12 @@ module SmSmsCampaignWebhook
       CampaignEngagement.new(payload: payload)
     end
 
+    # @return [Processable] SMS campaign payload processor
+    # @see [Processable]
+    def self.processor
+      @processor ||= DefaultProcessor
+    end
+
     # @return [ActiveSupport::Logger] Abstraction of app logger
     def self.logger
       @logger ||= Rails.logger

--- a/app/processors/sm_sms_campaign_webhook/default_processor.rb
+++ b/app/processors/sm_sms_campaign_webhook/default_processor.rb
@@ -7,16 +7,5 @@ module SmSmsCampaignWebhook
   # @see Processable
   class DefaultProcessor
     include Processable
-
-    # @param campaign_engagement [CampaignEngagement] modeled payload
-    def self.process_campaign_engagement(campaign_engagement)
-      logger.debug "#{name} - NOOP campaign engagement processing: #{campaign_engagement.inspect}"
-    end
-
-    # @return [ActiveSupport::Logger] Abstraction of app logger
-    def self.logger
-      @logger ||= Rails.logger
-    end
-    private_class_method :logger
   end
 end

--- a/app/processors/sm_sms_campaign_webhook/default_processor.rb
+++ b/app/processors/sm_sms_campaign_webhook/default_processor.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_dependency "sm_sms_campaign_webhook/processable"
+
+module SmSmsCampaignWebhook
+  # Default processor with NOOP implementations.
+  # @see Processable
+  class DefaultProcessor
+    include Processable
+
+    # @param campaign_engagement [CampaignEngagement] modeled payload
+    def self.process_campaign_engagement(campaign_engagement)
+      logger.debug "#{name} - NOOP campaign engagement processing: #{campaign_engagement.inspect}"
+    end
+
+    # @return [ActiveSupport::Logger] Abstraction of app logger
+    def self.logger
+      @logger ||= Rails.logger
+    end
+    private_class_method :logger
+  end
+end

--- a/app/processors/sm_sms_campaign_webhook/processable.rb
+++ b/app/processors/sm_sms_campaign_webhook/processable.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module SmSmsCampaignWebhook
+  # Define behavior that SMS campaign payload processors must implement.
+  module Processable
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Campaign engagement operation sends modeled campaign engagement payload
+      # to this method for applying business logic. Implementors should define
+      # the app behavior to properly handle this data.
+      #
+      # @param campaign_engagement [CampaignEngagement] modeled payload
+      # @raise [NotImplementedError] requiring implementing class to define behavior
+      def process_campaign_engagement(campaign_engagement)
+        raise NotImplementedError,
+              "#{self.class} must implement .process_campaign_engagement receiving campaign_engagement param"
+      end
+    end
+  end
+end

--- a/spec/operations/campaign_engagement_operation_spec.rb
+++ b/spec/operations/campaign_engagement_operation_spec.rb
@@ -39,4 +39,12 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagementOperation do
       ).to be_a(SmSmsCampaignWebhook::CampaignEngagement)
     end
   end
+
+  describe ".processor" do
+    it "returns default processor" do
+      expect(described_class.processor).to eq(
+        SmSmsCampaignWebhook::DefaultProcessor
+      )
+    end
+  end
 end

--- a/spec/operations/campaign_engagement_operation_spec.rb
+++ b/spec/operations/campaign_engagement_operation_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagementOperation do
       end
     end
 
-    it "returns payload modeled as campaign engagement" do
-      expect(
-        described_class.process(method_params)
-      ).to be_a(SmSmsCampaignWebhook::CampaignEngagement)
+    it "processes payload modeled as campaign engagement" do
+      expect(described_class.processor).to receive(:process_campaign_engagement)
+        .with(an_instance_of(SmSmsCampaignWebhook::CampaignEngagement))
+      described_class.process(method_params)
     end
   end
 

--- a/spec/processors/default_processor_spec.rb
+++ b/spec/processors/default_processor_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe SmSmsCampaignWebhook::DefaultProcessor do
+  it_behaves_like "implementation of processable"
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,8 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
-require_relative "./support/helpers/sms_campaign_payload"
+# Require spec/support files
+Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
   # Mix custom helpers in to tests.

--- a/spec/support/shared_examples/processable_behavior.rb
+++ b/spec/support/shared_examples/processable_behavior.rb
@@ -13,10 +13,10 @@ RSpec.shared_examples "implementation of processable" do
       end.to raise_error(ArgumentError)
     end
 
-    it "does not raise an error" do
+    it "raises a not implemented error" do
       expect do
         described_class.process_campaign_engagement(campaign_engagement)
-      end.to_not raise_error
+      end.to raise_error(NotImplementedError)
     end
   end
 end

--- a/spec/support/shared_examples/processable_behavior.rb
+++ b/spec/support/shared_examples/processable_behavior.rb
@@ -1,0 +1,22 @@
+RSpec.shared_examples "implementation of processable" do
+  describe ".process_campaign_engagement" do
+    let(:campaign_engagement) do
+      SmSmsCampaignWebhook::CampaignEngagement.new(payload: payload)
+    end
+    let(:payload) do
+      campaign_engagement_hash
+    end
+
+    it "raises an error without any arguments" do
+      expect do
+        described_class.process_campaign_engagement
+      end.to raise_error(ArgumentError)
+    end
+
+    it "does not raise an error" do
+      expect do
+        described_class.process_campaign_engagement(campaign_engagement)
+      end.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
These commits close #13. This includes:

* Defining Processable behavior for processors receiving modeled data from operations
* Default processor with NOOP implementation
* Updating CampaignEngagementOperation.process to hand off modeled data to the processor
* Prepping CampaignEngagementOperation for processor configuration in future PRs