### PR TITLE
Add configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Processable behavior definition for app implementors
 - Default processor mixing in processable behavior with noisy errors
 - ActiveJob library for asynchronous handling of payload dispatching and processing
+- Configuration support for required app implementation values
 
 ### Changed
 - Require Ruby >= 2.5

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ class SmsPayloadProcessor
   include SmSmsCampaignWebhook::Processable
 
   # Implement required methods for Processable behavior.
+
+  # @param campaign_engagement [SmSmsCampaignWebhook::CampaignEngagement]
+  # def self.process_campaign_engagement(campaign_engagement)
+  #   # NOOP - I need to be implemented.
+  # end
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,46 @@ This sets the app up to receive POST requests from the SMS campaign service:
 
 Be sure to replace `/sms_campaign` with whatever mount point you choose. Once you share the webhook URI with your project manager, avoid changing it; they will configure it with the correspending SMS campaign!
 
+### Configure Webhook Options
+
+App implementors must configure some library options. Here are all supported configuration options with their default values for `config/initializers/sm_sms_campaign_webhook.rb`:
+
+```ruby
+require "sm_sms_campaign_webhook"
+
+SmSmsCampaignWebhook.config do |config|
+  # SMS campaign payload processor implementing SmSmsCampaignWebhook::Processable behavior.
+  # default: SmSmsCampaignWebhook::DefaultProcessor (raises errors for processing)
+  # config.processor = SmsPayloadProcessor
+end
+```
+
+#### Payload Processor
+
+The default payload processor will raise errors while processing. You are required to provide a working payload processor to properly handle the data received from the SMS campaign service.
+
+To create a processor, create a custom class mixing in `SmSmsCampaignWebhook::Processable` behavior. For example, we can create a custom processor named `SmsPayloadProcessor`:
+
+```ruby
+class SmsPayloadProcessor
+  include SmSmsCampaignWebhook::Processable
+
+  # Implement required methods for Processable behavior.
+end
+```
+
+This class will continue raising errors until the required methods are implemented. Please see the [Processable mixin](https://github.com/SouthernMade/sm_sms_campaign_webhook/blob/develop/app/processors/sm_sms_campaign_webhook/processable.rb) for expected method definitions.
+
+Finally the configuration needs to be updated to use the custom processor. Add this within the config block in `config/initializers/sm_sms_campaign_webhook.rb`:
+
+```ruby
+SmSmsCampaignWebhook.config do |config|
+  #...
+  config.processor = SmsPayloadProcessor
+  #...
+end
+```
+
 ## Development
 
 This gem uses [git-flow](https://github.com/nvie/gitflow) to manage deployments. The default branches are used to manage development and production code.

--- a/app/operations/sm_sms_campaign_webhook/campaign_engagement_operation.rb
+++ b/app/operations/sm_sms_campaign_webhook/campaign_engagement_operation.rb
@@ -21,10 +21,10 @@ module SmSmsCampaignWebhook
       processor.process_campaign_engagement(campaign_enagement)
     end
 
-    # @return [Processable] SMS campaign payload processor
-    # @see [Processable]
+    # @return [Processable] Configured SMS campaign payload processor
+    # @see SmSmsCampaignWebhook.processor
     def self.processor
-      @processor ||= DefaultProcessor
+      @processor ||= SmSmsCampaignWebhook.processor
     end
 
     # @return [ActiveSupport::Logger] Abstraction of app logger

--- a/lib/sm_sms_campaign_webhook.rb
+++ b/lib/sm_sms_campaign_webhook.rb
@@ -5,4 +5,14 @@ require "sm_sms_campaign_webhook/version"
 
 # Namespace for SMS campaign webhook.
 module SmSmsCampaignWebhook
+  # @return [Processable] SMS campaign payload processor used by operations
+  def self.processor
+    @processor ||= DefaultProcessor
+  end
+
+  # @param processor [Processable] Custom SMS campaign payload processor
+  # @see Processable
+  def self.processor=(processor)
+    @processor = processor
+  end
 end

--- a/lib/sm_sms_campaign_webhook.rb
+++ b/lib/sm_sms_campaign_webhook.rb
@@ -5,6 +5,11 @@ require "sm_sms_campaign_webhook/version"
 
 # Namespace for SMS campaign webhook.
 module SmSmsCampaignWebhook
+  # @return [SmSmsCampaignWebhook] self for configuration purposes
+  def self.config(&block)
+    yield self if block
+  end
+
   # @return [Processable] SMS campaign payload processor used by operations
   def self.processor
     @processor ||= DefaultProcessor

--- a/spec/operations/campaign_engagement_operation_spec.rb
+++ b/spec/operations/campaign_engagement_operation_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe SmSmsCampaignWebhook::CampaignEngagementOperation do
   end
 
   describe ".processor" do
-    it "returns default processor" do
+    it "returns configured processor" do
       expect(described_class.processor).to eq(
-        SmSmsCampaignWebhook::DefaultProcessor
+        SmSmsCampaignWebhook.processor
       )
     end
   end

--- a/spec/sm_sms_campaign_webhook_spec.rb
+++ b/spec/sm_sms_campaign_webhook_spec.rb
@@ -4,4 +4,35 @@ RSpec.describe SmSmsCampaignWebhook do
       expect(described_class::VERSION).to_not be_nil
     end
   end
+
+  describe ".processor" do
+    it "defaults to default processor" do
+      expect(
+        described_class.processor
+      ).to eq(SmSmsCampaignWebhook::DefaultProcessor)
+    end
+  end
+
+  describe ".processor=" do
+    let(:processor_klass) do
+      class MockProcessor
+        include SmSmsCampaignWebhook::Processable
+      end
+      MockProcessor
+    end
+
+    before do
+      @original_processor = described_class.processor
+    end
+
+    after do
+      described_class.instance_variable_set(:@processor, @original_processor)
+    end
+
+    it "updates process config" do
+      expect do
+        described_class.processor = processor_klass
+      end.to change(described_class, :processor).to(processor_klass)
+    end
+  end
 end

--- a/spec/sm_sms_campaign_webhook_spec.rb
+++ b/spec/sm_sms_campaign_webhook_spec.rb
@@ -5,6 +5,39 @@ RSpec.describe SmSmsCampaignWebhook do
     end
   end
 
+  describe ".config" do
+    let(:processor_klass) do
+      class MockProcessor
+        include SmSmsCampaignWebhook::Processable
+      end
+      MockProcessor
+    end
+
+    before do
+      @original_processor = described_class.processor
+    end
+
+    after do
+      described_class.instance_variable_set(:@processor, @original_processor)
+    end
+
+    it "does not raise an error without a block" do
+      expect do
+        described_class.config
+      end.to_not raise_error
+    end
+
+    it "updates library config values" do
+      # Update the config values.
+      described_class.config do |config|
+        config.processor = processor_klass
+      end
+      
+      # Verify that the values were updated.
+      expect(described_class.processor).to eq(processor_klass)
+    end
+  end
+
   describe ".processor" do
     it "defaults to default processor" do
       expect(

--- a/spec/sm_sms_campaign_webhook_spec.rb
+++ b/spec/sm_sms_campaign_webhook_spec.rb
@@ -1,5 +1,7 @@
 RSpec.describe SmSmsCampaignWebhook do
-  it "has a version number" do
-    expect(SmSmsCampaignWebhook::VERSION).not_to be nil
+  describe "VERSION" do
+    it "has a version number" do
+      expect(described_class::VERSION).to_not be_nil
+    end
   end
 end


### PR DESCRIPTION
These commits close #14. This includes:

* Making payload processor configurable
* Adding config method for use in an ininitializer
* Updating README with configuration defaults + expectations