### PR TITLE
Update webhook action to require auth token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Mountable Rails engine as API
 - POST /api/webhook resource requiring JSON payload for asynchronous dispatching and processing
+- Require inbound POST requests be authorization requests with an auth token
 - Support for Rails 5.2.x, 6.0.x
 - Data models for campaign engagement event payloads
 - Helper method to get specific campaign engagement answer

--- a/README.md
+++ b/README.md
@@ -35,7 +35,23 @@ Or install it yourself as:
 
 ## Usage
 
-Right now, nothing happens! Soon, some useful details will emerge about how to ingest the SMS campaign payloads.
+These are the steps to configure your app to be ready to capture SMS campaign service payloads.
+
+### Set SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN value in ENV
+
+The value is required to be an ENV value so that we avoid leaking production auth token values. It will be used to authorize payload requests from the SMS campaign service.
+
+Set this value using the rails secret generator:
+
+```ruby
+$ bundle exec rails secret
+```
+
+And copy the result to your `.env` or applicable config file:
+
+```
+SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN="******"
+```
 
 ### Set Backend for ActiveJob
 

--- a/app/controllers/sm_sms_campaign_webhook/application_controller.rb
+++ b/app/controllers/sm_sms_campaign_webhook/application_controller.rb
@@ -1,8 +1,21 @@
 # frozen_string_literal: true
 
+require "action_controller/metal/http_authentication"
+
 module SmSmsCampaignWebhook
   # General webhook controller configuration.
   class ApplicationController < ActionController::API
-    # protect_from_forgery with: :exception
+    include ActionController::HttpAuthentication::Token::ControllerMethods
+
+    before_action :authenticate
+
+    protected
+
+    # Verify auth token is present and matches the configured value.
+    def authenticate
+      authenticate_or_request_with_http_token do |token, options|
+        ActiveSupport::SecurityUtils.secure_compare(token, SmSmsCampaignWebhook.auth_token)
+      end
+    end
   end
 end

--- a/app/exceptions/sm_sms_campaign_webhook/missing_config_error.rb
+++ b/app/exceptions/sm_sms_campaign_webhook/missing_config_error.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module SmSmsCampaignWebhook
+  # Error type for missing config values for this library.
+  class MissingConfigError < Error; end
+end

--- a/lib/sm_sms_campaign_webhook.rb
+++ b/lib/sm_sms_campaign_webhook.rb
@@ -10,6 +10,15 @@ module SmSmsCampaignWebhook
     yield self if block
   end
 
+  # @return [String] SMS campaign webhook auth token
+  # @raise [MissingConfigError] when ENV does not contain SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN value
+  def self.auth_token
+    @auth_token ||= ENV.fetch("SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN") do
+      raise MissingConfigError,
+            "ENV does not contain SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN value"
+    end
+  end
+
   # @return [Processable] SMS campaign payload processor used by operations
   def self.processor
     @processor ||= DefaultProcessor

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,9 @@ require "rspec/rails"
 # Require spec/support files
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
+# Set expected lib related values.
+ENV["SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN"] = SecureRandom.hex(64)
+
 RSpec.configure do |config|
   # Mix custom helpers in to tests.
   config.include Helpers::SmsCampaignPayload

--- a/spec/sm_sms_campaign_webhook_spec.rb
+++ b/spec/sm_sms_campaign_webhook_spec.rb
@@ -1,3 +1,5 @@
+require "securerandom"
+
 RSpec.describe SmSmsCampaignWebhook do
   describe "VERSION" do
     it "has a version number" do
@@ -32,9 +34,38 @@ RSpec.describe SmSmsCampaignWebhook do
       described_class.config do |config|
         config.processor = processor_klass
       end
-      
+
       # Verify that the values were updated.
       expect(described_class.processor).to eq(processor_klass)
+    end
+  end
+
+  describe ".auth_token" do
+    context "when SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN env value is present" do
+      let(:auth_token) do
+        ENV.fetch("SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN")
+      end
+
+      it "defaults to SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN env value" do
+        expect(described_class.auth_token).to eq(auth_token)
+      end
+    end
+
+    context "when SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN env value is not present" do
+      before do
+        @original_auth_token = ENV.delete("SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN")
+        described_class.instance_variable_set(:@auth_token, nil)
+      end
+
+      after do
+        ENV["SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN"] = @original_auth_token
+      end
+
+      it "raises an error" do
+        expect do
+          described_class.auth_token
+        end.to raise_error(described_class::MissingConfigError)
+      end
     end
   end
 


### PR DESCRIPTION
These commits close #15. This includes:

* Adding auth_token config value that must be set by ENV value SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN
* Updating controller to authorize requests with auth token
* Update README to instruct on setting a value