### PR TITLE
Add config generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,25 @@ Or install it yourself as:
 
 These are the steps to configure your app to be ready to capture SMS campaign service payloads.
 
+### Auto Generate Config
+
+You can setup most app configuration by running the generator:
+
+```
+$ bundle exec rails generate sm_sms_campaign_webhook:install
+```
+
+Some things will still require manual configuration and will be identified after generation.
+
+If you prefer to setup everything by hand, continue to the next sections!
+
 ### Set SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN value in ENV
 
 The value is required to be an ENV value so that we avoid leaking production auth token values. It will be used to authorize payload requests from the SMS campaign service.
 
 Set this value using the rails secret generator:
 
-```ruby
+```
 $ bundle exec rails secret
 ```
 

--- a/lib/generators/sm_sms_campaign_webhook/install/USAGE
+++ b/lib/generators/sm_sms_campaign_webhook/install/USAGE
@@ -5,4 +5,5 @@ Example:
     rails generate sm_sms_campaign_webhook:install
 
     This will create:
+        app/processors/sms_payload_processor.rb
         config/initializers/sm_sms_campaign_webhook.rb

--- a/lib/generators/sm_sms_campaign_webhook/install/USAGE
+++ b/lib/generators/sm_sms_campaign_webhook/install/USAGE
@@ -7,3 +7,6 @@ Example:
     This will create:
         app/processors/sms_payload_processor.rb
         config/initializers/sm_sms_campaign_webhook.rb
+
+    This will mount the engine in:
+        config/routes.rb

--- a/lib/generators/sm_sms_campaign_webhook/install/USAGE
+++ b/lib/generators/sm_sms_campaign_webhook/install/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Configures the app to handle inbound requests from the SMS campaign service.
+
+Example:
+    rails generate sm_sms_campaign_webhook:install
+
+    This will create:
+        config/initializers/sm_sms_campaign_webhook.rb

--- a/lib/generators/sm_sms_campaign_webhook/install/install_generator.rb
+++ b/lib/generators/sm_sms_campaign_webhook/install/install_generator.rb
@@ -13,6 +13,11 @@ module SmSmsCampaignWebhook
       def copy_initializer
         template "sm_sms_campaign_webhook.rb", "config/initializers/sm_sms_campaign_webhook.rb"
       end
+
+      # Copy processor template to app/processors
+      def copy_processor
+        template "sms_payload_processor.rb.erb", "app/processors/sms_payload_processor.rb"
+      end
     end
   end
 end

--- a/lib/generators/sm_sms_campaign_webhook/install/install_generator.rb
+++ b/lib/generators/sm_sms_campaign_webhook/install/install_generator.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails/generators/base"
+
+module SmSmsCampaignWebhook
+  # Namespace for generators provided by the gem.
+  module Generators
+    # Installs files to prep an app for SMS campaign webhook.
+    class InstallGenerator < Rails::Generators::Base
+      source_root File.expand_path("templates", __dir__)
+
+      # Copy initializer template to config/initializers
+      def copy_initializer
+        template "sm_sms_campaign_webhook.rb", "config/initializers/sm_sms_campaign_webhook.rb"
+      end
+    end
+  end
+end

--- a/lib/generators/sm_sms_campaign_webhook/install/install_generator.rb
+++ b/lib/generators/sm_sms_campaign_webhook/install/install_generator.rb
@@ -18,6 +18,11 @@ module SmSmsCampaignWebhook
       def copy_processor
         template "sms_payload_processor.rb.erb", "app/processors/sms_payload_processor.rb"
       end
+
+      # Dump the README for the app developer
+      def show_readme
+        readme "README" if behavior == :invoke
+      end
     end
   end
 end

--- a/lib/generators/sm_sms_campaign_webhook/install/install_generator.rb
+++ b/lib/generators/sm_sms_campaign_webhook/install/install_generator.rb
@@ -19,6 +19,13 @@ module SmSmsCampaignWebhook
         template "sms_payload_processor.rb.erb", "app/processors/sms_payload_processor.rb"
       end
 
+      # Mount engine to path in config/routes.rb
+      def add_mount_path
+        insert_into_file "config/routes.rb",
+                         "  mount SmSmsCampaignWebhook::Engine => \"/sms_campaign\"\n",
+                         after: "Rails.application.routes.draw do\n"
+      end
+
       # Dump the README for the app developer
       def show_readme
         readme "README" if behavior == :invoke

--- a/lib/generators/sm_sms_campaign_webhook/install/templates/README
+++ b/lib/generators/sm_sms_campaign_webhook/install/templates/README
@@ -6,12 +6,7 @@ Some setup you must do manually if you haven't yet:
 
        $ bundle exec rails secret
 
-  2. Mount the webhook engine in config/routes.rb to accept requests.
-     For example:
-
-       mount SmSmsCampaignWebhook::Engine => "/sms_campaign"
-
-  3. Prep the app for ActiveJob using Sidekiq. In config/application.rb:
+  2. Prep the app for ActiveJob using Sidekiq. In config/application.rb:
 
        config.active_job.queue_adapter = :sidekiq
 
@@ -19,7 +14,7 @@ Some setup you must do manually if you haven't yet:
 
        worker: bundle exec sidekiq --config config/sidekiq.yml
 
-  4. Implement SmsPayloadProcessor behavior. Remember, the generated processor
+  3. Implement SmsPayloadProcessor behavior. Remember, the generated processor
      provides the skeleton but will raise errors out of the box. Data handling
      is app specific!
 

--- a/lib/generators/sm_sms_campaign_webhook/install/templates/README
+++ b/lib/generators/sm_sms_campaign_webhook/install/templates/README
@@ -1,0 +1,30 @@
+================================================================================
+
+Some setup you must do manually if you haven't yet:
+
+  1. Set the ENV value SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN with a Rails secret:
+
+       $ bundle exec rails secret
+
+  2. Mount the webhook engine in config/routes.rb to accept requests.
+     For example:
+
+       mount SmSmsCampaignWebhook::Engine => "/sms_campaign"
+
+  3. Prep the app for ActiveJob using Sidekiq. In config/application.rb:
+
+       config.active_job.queue_adapter = :sidekiq
+
+     In Procfile or appropriate app launch config:
+
+       worker: bundle exec sidekiq --config config/sidekiq.yml
+
+  4. Implement SmsPayloadProcessor behavior. Remember, the generated processor
+     provides the skeleton but will raise errors out of the box. Data handling
+     is app specific!
+
+This will configure the app to be ready to accept SMS campaign service payloads.
+
+Happy hacking!
+
+================================================================================

--- a/lib/generators/sm_sms_campaign_webhook/install/templates/sm_sms_campaign_webhook.rb
+++ b/lib/generators/sm_sms_campaign_webhook/install/templates/sm_sms_campaign_webhook.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "sm_sms_campaign_webhook"
+
+SmSmsCampaignWebhook.config do |config|
+  # SMS campaign payload processor implementing SmSmsCampaignWebhook::Processable behavior.
+  # default: SmSmsCampaignWebhook::DefaultProcessor (raises errors for processing)
+  # config.processor = SmsPayloadProcessor
+end

--- a/lib/generators/sm_sms_campaign_webhook/install/templates/sm_sms_campaign_webhook.rb
+++ b/lib/generators/sm_sms_campaign_webhook/install/templates/sm_sms_campaign_webhook.rb
@@ -5,5 +5,5 @@ require "sm_sms_campaign_webhook"
 SmSmsCampaignWebhook.config do |config|
   # SMS campaign payload processor implementing SmSmsCampaignWebhook::Processable behavior.
   # default: SmSmsCampaignWebhook::DefaultProcessor (raises errors for processing)
-  # config.processor = SmsPayloadProcessor
+  config.processor = SmsPayloadProcessor
 end

--- a/lib/generators/sm_sms_campaign_webhook/install/templates/sms_payload_processor.rb.erb
+++ b/lib/generators/sm_sms_campaign_webhook/install/templates/sms_payload_processor.rb.erb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Processes SMS campaign service payloads.
+# @see https://github.com/SouthernMade/sm_sms_campaign_webhook/blob/v<%= SmSmsCampaignWebhook::VERSION %>/app/processors/sm_sms_campaign_webhook/processable.rb SmSmsCampaignWebhook::Processable
+class SmsPayloadProcessor
+  include SmSmsCampaignWebhook::Processable
+
+  # @param campaign_enagement [SmSmsCampaignWebhook::CampaignEngagement]
+  # @see https://github.com/SouthernMade/sm_sms_campaign_webhook/blob/v<%= SmSmsCampaignWebhook::VERSION %>/app/models/sm_sms_campaign_webhook/campaign_engagement.rb SmSmsCampaignWebhook::CampaignEngagement
+  # @todo Implement business logic to process campaign engagement.
+  # def self.process_campaign_engagement(campaign_engagement)
+  # end
+end


### PR DESCRIPTION
These commits close #16. This includes:

* Adding Rails generator that preps an app to use the gem
* Dump README with final instructions after executing the installer
* Update README with info about how to use it

In a sample app, I configured the Gemfile to point to this branch:

```ruby
gem 'sm_sms_campaign_webhook',
    github: 'SouthernMade/sm_sms_campaign_webhook',
    branch: 'feature/add-config-generator'
```

And then I ran the generator in the console:

```
cdykes@Camerons-MBP:~/projects/sm/sm_webhook_app2(master*)$ be rails generate sm_sms_campaign_webhook:install --help
Running via Spring preloader in process 46325
Usage:
  rails generate sm_sms_campaign_webhook:install [options]

Options:
  [--skip-namespace], [--no-skip-namespace]  # Skip namespace (affects only isolated applications)

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Description:
    Configures the app to handle inbound requests from the SMS campaign service.

Example:
    rails generate sm_sms_campaign_webhook:install

    This will create:
        app/processors/sms_payload_processor.rb
        config/initializers/sm_sms_campaign_webhook.rb

    This will mount the engine in:
        config/routes.rb
cdykes@Camerons-MBP:~/projects/sm/sm_webhook_app2(master*)$ be rails generate sm_sms_campaign_webhook:install
Running via Spring preloader in process 46466
      create  config/initializers/sm_sms_campaign_webhook.rb
      create  app/processors/sms_payload_processor.rb
      insert  config/routes.rb
================================================================================

Some setup you must do manually if you haven't yet:

  1. Set the ENV value SM_SMS_CAMPAIGN_WEBHOOK_AUTH_TOKEN with a Rails secret:

       $ bundle exec rails secret

  2. Prep the app for ActiveJob using Sidekiq. In config/application.rb:

       config.active_job.queue_adapter = :sidekiq

     In Procfile or appropriate app launch config:

       worker: bundle exec sidekiq --config config/sidekiq.yml

  3. Implement SmsPayloadProcessor behavior. Remember, the generated processor
     provides the skeleton but will raise errors out of the box. Data handling
     is app specific!

This will configure the app to be ready to accept SMS campaign service payloads.

Happy hacking!

================================================================================
cdykes@Camerons-MBP:~/projects/sm/sm_webhook_app2(master+*)$ gst
On branch master
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   Gemfile
	modified:   Gemfile.lock
	modified:   config/routes.rb

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	app/processors/
	config/initializers/sm_sms_campaign_webhook.rb

no changes added to commit (use "git add" and/or "git commit -a")
cdykes@Camerons-MBP:~/projects/sm/sm_webhook_app2(master+*)$ gd config/routes.rb
diff --git a/config/routes.rb b/config/routes.rb
index 787824f..88eaaed 100644
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  mount SmSmsCampaignWebhook::Engine => "/sms_campaign"
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end
cdykes@Camerons-MBP:~/projects/sm/sm_webhook_app2(master+*)$ cat config/initializers/sm_sms_campaign_webhook.rb
# frozen_string_literal: true

require "sm_sms_campaign_webhook"

SmSmsCampaignWebhook.config do |config|
  # SMS campaign payload processor implementing SmSmsCampaignWebhook::Processable behavior.
  # default: SmSmsCampaignWebhook::DefaultProcessor (raises errors for processing)
  config.processor = SmsPayloadProcessor
end
cdykes@Camerons-MBP:~/projects/sm/sm_webhook_app2(master+*)$ cat app/processors/sms_payload_processor.rb
# frozen_string_literal: true

# Processes SMS campaign service payloads.
# @see https://github.com/SouthernMade/sm_sms_campaign_webhook/blob/v0.1.1/app/processors/sm_sms_campaign_webhook/processable.rb SmSmsCampaignWebhook::Processable
class SmsPayloadProcessor
  include SmSmsCampaignWebhook::Processable

  # @param campaign_enagement [SmSmsCampaignWebhook::CampaignEngagement]
  # @see https://github.com/SouthernMade/sm_sms_campaign_webhook/blob/v0.1.1/app/models/sm_sms_campaign_webhook/campaign_engagement.rb SmSmsCampaignWebhook::CampaignEngagement
  # @todo Implement business logic to process campaign engagement.
  # def self.process_campaign_engagement(campaign_engagement)
  # end
end
```

We can see all config files, changes, and useful info were successfully generated.