### PR TITLE
Update gem package contents

### DIFF
--- a/app/controllers/sm_sms_campaign_webhook/application_controller.rb
+++ b/app/controllers/sm_sms_campaign_webhook/application_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "action_controller/metal/http_authentication"
+require "active_support/security_utils"
 
 module SmSmsCampaignWebhook
   # General webhook controller configuration.

--- a/app/controllers/sm_sms_campaign_webhook/webhook_controller.rb
+++ b/app/controllers/sm_sms_campaign_webhook/webhook_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json"
 require_dependency "sm_sms_campaign_webhook/application_controller"
 
 module SmSmsCampaignWebhook

--- a/sm_sms_campaign_webhook.gemspec
+++ b/sm_sms_campaign_webhook.gemspec
@@ -18,12 +18,13 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/SouthernMade/sm_sms_campaign_webhook/blob/develop/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.files = Dir[
+    "{app,config,lib}/**/*",
+    "CHANGELOG.md",
+    "LICENSE.txt",
+    "README.md",
+    "sm_sms_campaign_webhook.gemspec"
+  ]
   spec.require_paths = ["lib"]
 
   # Required version of Ruby guided by Rails.

--- a/sm_sms_campaign_webhook.gemspec
+++ b/sm_sms_campaign_webhook.gemspec
@@ -3,19 +3,19 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "sm_sms_campaign_webhook/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "sm_sms_campaign_webhook"
-  spec.version       = SmSmsCampaignWebhook::VERSION
-  spec.authors       = ["Cameron Dykes", "Matt Mueller"]
-  spec.email         = ["cameron@southernmade.com", "matt@southernmade.com"]
-
-  spec.summary       = %q{Middleware providing webhook for Southern Made SMS Campaign Engagement.}
-  spec.homepage      = "https://github.com/SouthernMade/sm_sms_campaign_webhook"
-  spec.license       = "MIT"
+  spec.name        = "sm_sms_campaign_webhook"
+  spec.version     = SmSmsCampaignWebhook::VERSION
+  spec.license     = "MIT"
+  spec.summary     = %q{Middleware providing webhook for Southern Made SMS Campaign Engagement.}
+  spec.description = %q{Middleware providing webhook for Southern Made SMS Campaign Engagement.}
+  spec.homepage    = "https://github.com/SouthernMade/sm_sms_campaign_webhook"
+  spec.authors     = ["Cameron Dykes", "Matt Mueller"]
+  spec.email       = ["cameron@southernmade.com", "matt@southernmade.com"]
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/SouthernMade/sm_sms_campaign_webhook"
-  spec.metadata["changelog_uri"] = "https://github.com/SouthernMade/sm_sms_campaign_webhook/blob/develop/CHANGELOG.md"
+  spec.metadata["homepage_uri"]      = spec.homepage
+  spec.metadata["source_code_uri"]   = spec.homepage
+  spec.metadata["changelog_uri"]     = "#{spec.homepage}/blob/develop/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
   spec.files = Dir[

--- a/spec/requests/api_webhook_spec.rb
+++ b/spec/requests/api_webhook_spec.rb
@@ -1,3 +1,4 @@
+require "json"
 require "securerandom"
 
 RSpec.describe "API webhook", type: :request do


### PR DESCRIPTION
These commits close #21. This includes:

* Adding some additional requires
* Updating packages files in the gemspec
* Tidying up the gemspec

To verify that the contents are indeed what we prefer, I packaged up the gem and copied it to a sample app directory:

```
cdykes@Camerons-MBP:~/projects/sm/sm_sms_campaign_webhook(feature/update-gem-package-contents)$ be rake build
sm_sms_campaign_webhook 0.1.1 built to pkg/sm_sms_campaign_webhook-0.1.1.gem.
cdykes@Camerons-MBP:~/projects/sm/sm_sms_campaign_webhook(feature/update-gem-package-contents)$ cp pkg/sm_sms_campaign_webhook-0.1.1.gem ../sm_webhook_app2/.
```

Then in the sample app directory, I installed the gem and opened it up:

```
cdykes@Camerons-MBP:~/projects/sm/sm_webhook_app2(master+*)$ ll sm_sms_campaign_webhook-0.1.1.gem
-rw-r--r--  1 cdykes  staff  14336 Jul 25 10:18 sm_sms_campaign_webhook-0.1.1.gem
cdykes@Camerons-MBP:~/projects/sm/sm_webhook_app2(master+*)$ gem uninstall sm_sms_campaign_webhook
Successfully uninstalled sm_sms_campaign_webhook-0.1.1
cdykes@Camerons-MBP:~/projects/sm/sm_webhook_app2(master+*)$ gem install sm_sms_campaign_webhook
Successfully installed sm_sms_campaign_webhook-0.1.1
Parsing documentation for sm_sms_campaign_webhook-0.1.1
Installing ri documentation for sm_sms_campaign_webhook-0.1.1
Done installing documentation for sm_sms_campaign_webhook after 0 seconds
1 gem installed
cdykes@Camerons-MBP:~/projects/sm/sm_webhook_app2(master+*)$ bundle open sm_sms_campaign_webhook
```

We can see in the screenshot that the desired gem structure is in place (no test files, development directories, etc):

![Screen Shot 2019-07-25 at 10 19 42 AM](https://user-images.githubusercontent.com/22482/61886941-3c4dcc80-aec6-11e9-8206-b003348508f5.png)

Finally, I verified that the install generator is accessible:

```
cdykes@Camerons-MBP:~/projects/sm/sm_webhook_app2(master+*)$ be rails generate sm_sms_campaign_webhook:install --help
Running via Spring preloader in process 27741
Usage:
  rails generate sm_sms_campaign_webhook:install [options]

Options:
  [--skip-namespace], [--no-skip-namespace]  # Skip namespace (affects only isolated applications)

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Description:
    Configures the app to handle inbound requests from the SMS campaign service.

Example:
    rails generate sm_sms_campaign_webhook:install

    This will create:
        app/processors/sms_payload_processor.rb
        config/initializers/sm_sms_campaign_webhook.rb

    This will mount the engine in:
        config/routes.rb
```