### PR TITLE
Update CI rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.6.6
-  - 2.7.2
-  - 3.0.0
+  - 2.6.7
+  - 2.7.3
+  - 3.0.1
 gemfile:
   - ci/gemfiles/Gemfile.rails-6.0.x
   - ci/gemfiles/Gemfile.rails-6.1.x

--- a/sm_sms_campaign_webhook.gemspec
+++ b/sm_sms_campaign_webhook.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   # Development + test dependencies.
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec-rails", "~> 4.0"
+  spec.add_development_dependency "rspec-rails", "~> 5.0"
   spec.add_development_dependency "simplecov", "~> 0.20"
   spec.add_development_dependency "standard"
   spec.add_development_dependency "yard", "~> 0.9"

--- a/sm_sms_campaign_webhook.gemspec
+++ b/sm_sms_campaign_webhook.gemspec
@@ -43,6 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec-rails", "~> 5.0"
   spec.add_development_dependency "simplecov", "~> 0.20"
-  spec.add_development_dependency "standard"
+  spec.add_development_dependency "standard", "~> 1.0"
   spec.add_development_dependency "yard", "~> 0.9"
 end


### PR DESCRIPTION
Currently these versions are not available in Travis CI. Check back periodically for support and then re-run the specs.

https://rubies.travis-ci.org